### PR TITLE
verify gemma 3n E2B and add sample script

### DIFF
--- a/docs/models/samples/gemma3n_e2b.py
+++ b/docs/models/samples/gemma3n_e2b.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""
+This example demonstrates how to use gemma-3n-E2B-it model with vLLM.
+Requirements:
+- vLLM: v0.11.0 or higher
+- vLLM-metax: v0.11.0 or higher
+- MACA SDK: 3.2.x.x or higher
+"""
+
+from vllm import LLM, SamplingParams
+
+if __name__ == "__main__":
+    sampling_params = SamplingParams(
+        temperature=0.7,
+        top_p=0.9,
+        max_tokens=200
+    )
+
+    llm = LLM(model="google/gemma-3n-E2B-it", trust_remote_code=True)
+
+    prompts = [
+        "Hello, my name is",
+        "The president of the United States is",
+        "The capital of France is",
+        "The future of AI is",
+    ]
+
+    outputs = llm.generate(prompts, sampling_params)
+
+    for output in outputs:
+        prompt = output.prompt
+        generated_text = output.outputs[0].text
+        print(f"Prompt: {prompt!r}, Generated text: {generated_text!r}")

--- a/docs/models/samples/gemma3n_e2b.py
+++ b/docs/models/samples/gemma3n_e2b.py
@@ -5,6 +5,7 @@ Requirements:
 - vLLM: v0.11.0 or higher
 - vLLM-metax: v0.11.0 or higher
 - MACA SDK: 3.2.x.x or higher
+- timm: run `pip install timm`
 """
 
 from vllm import LLM, SamplingParams

--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -28,6 +28,7 @@ Here the plugin would list all the **tested** model on Maca.
 | `Ernie4_5ForCausalLM` | Ernie4.5 | `baidu/ERNIE-4.5-0.3B-PT`, etc. | ✅︎ | ✅︎ |
 | `Ernie4_5_MoeForCausalLM` | Ernie4.5MoE | `baidu/ERNIE-4.5-21B-A3B-PT`, `baidu/ERNIE-4.5-300B-A47B-PT`, etc. |✅︎| ✅︎ |
 | `FalconForCausalLM` | Falcon | `tiiuae/falcon-7b`, `tiiuae/falcon-40b`, `tiiuae/falcon-rw-7b`, etc. | | ✅︎ |
+| `Gemma3nForCausalLM` | Gemma 3n | `google/gemma-3n-E2B-it` | ✅︎ | ✅︎ |
 | `GlmForCausalLM` | GLM-4 | `zai-org/glm-4-9b-chat-hf`, etc. | ✅︎ | ✅︎ |
 | `Glm4ForCausalLM` | GLM-4-0414 | `zai-org/GLM-4-32B-0414`, etc. | ✅︎ | ✅︎ |
 | `Glm4MoeForCausalLM` | GLM-4.5, GLM-4.6 | `zai-org/GLM-4.5`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
<!-- markdownlint-disable -->
verify gemma 3n E2B and add sample script

在 MACA 平台测试 vllm 是否能够运行 gemma 3n E2B.

运行 gemma 3n E2B 需要安装 timm, 运行下面的命令即可安装;

```
pip install timm
```

离线运行和在线运行均可.

离线运行结果:

<img width="1457" height="902" alt="gemma3n_e2b_offline" src="https://github.com/user-attachments/assets/c1c82c6a-4846-404c-a48b-baa3774c9c58" />

在线运行结果:

<img width="1448" height="899" alt="gemma3n_e2b_server" src="https://github.com/user-attachments/assets/fcd28a25-227d-40e9-8595-8db6da34518c" />

<img width="1457" height="906" alt="gemma3n_e2b_client" src="https://github.com/user-attachments/assets/660876bf-7d07-4ff7-96d2-6dc68c4f5350" />
