### PR TITLE
[fix] fix fused moe error in deepseek-r1-awq

### DIFF
--- a/vllm_metax/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_metax/model_executor/layers/fused_moe/fused_moe.py
@@ -1442,8 +1442,8 @@ def try_get_optimal_moe_config(
     else:
         # First try to load optimal config from the file
         E, _, N = w2_shape
-        if dtype == "int4_w4a16":
-            N = N * 2
+        # if dtype == "int4_w4a16":
+        #     N = N * 2
         block_n = block_shape[0] if block_shape else 0
         block_k = block_shape[1] if block_shape else 0
         configs = get_moe_configs(E, N, dtype, block_n, block_k)

--- a/vllm_metax/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm_metax/model_executor/layers/fused_moe/fused_moe.py
@@ -1442,6 +1442,9 @@ def try_get_optimal_moe_config(
     else:
         # First try to load optimal config from the file
         E, _, N = w2_shape
+        # TODO: This is a temporary fix for deepseek-r1-awq.
+        # The N = N * 2 adjustment causes issues with Triton compilation for
+        # this model. A proper fix should be investigated.
         # if dtype == "int4_w4a16":
         #     N = N * 2
         block_n = block_shape[0] if block_shape else 0


### PR DESCRIPTION
<!-- markdownlint-disable -->
This PR temporarily disables the N = N * 2 adjustment in try_get_optimal_moe_config for dtype == "int4_w4a16".


## Purpose
This change unblocks DeepSeek-R1-AWQ from failing during Triton compilation / CUDA graph warmup when using the fused MoE WNA16 (GPTQ/AWQ) kernel path.
## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
