### PR TITLE
fix: add modules_to_not_convert to AWQ config

### DIFF
--- a/vllm_metax/quant_config/awq.py
+++ b/vllm_metax/quant_config/awq.py
@@ -52,6 +52,7 @@ class MacaAWQConfig(AWQConfig):
                 "group_size": self.group_size,
                 "zero_point": self.zero_point,
                 "lm_head": False,
+                "modules_to_not_convert": self.modules_to_not_convert,
             }
             return MacaMoeWNA16Config.from_config(config).get_quant_method(
                 layer, prefix


### PR DESCRIPTION
## Purpose

修复AWQ量化权重加载失败问题。 

未传递modules_to_not_convert数组，MacaMoeWNA16Config无法识别未量化的模型层，最终导致在加载未量化的MoE权重时失败。

## Test Plan

## Test Result

## (Optional) Documentation Update

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
