### PR TITLE
[BugFix]: Rename int4_in8 to int4_w4a8 in FusedMoEQuantConfig

### DIFF
--- a/vllm_metax/patch/model_executor/utils.py
+++ b/vllm_metax/patch/model_executor/utils.py
@@ -50,9 +50,9 @@ def _int8_quantize(
 @dataclass
 class MacaFusedMoEQuantConfig(FusedMoEQuantConfig):
     @property
-    def use_int4_int8(self):
+    def use_int4_w4a8(self):
         return self._a1.dtype == "int8" and self._w1.dtype == "int4"
 
 
 utils._int8_quantize = _int8_quantize
-FusedMoEQuantConfig.use_int4_int8 = MacaFusedMoEQuantConfig.use_int4_int8
+FusedMoEQuantConfig.use_int4_w4a8 = MacaFusedMoEQuantConfig.use_int4_w4a8


### PR DESCRIPTION
## Purpose
<img width="1409" height="175" alt="image" src="https://github.com/user-attachments/assets/b16d50ea-46bc-4efd-9dfe-481dfda7449f" />

Fix Qwen3-35B-A3B startup failure by renaming int4_in8 to int4_w4a8 in FusedMoEQuantConfig.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
