### PR TITLE
optimize variable-length speculative decode performance

### DIFF
--- a/vllm_metax/patch/dp_fix/__init__.py
+++ b/vllm_metax/patch/dp_fix/__init__.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
-from . import coordinator, shared_fused_moe, fused_moe_layer
+from . import coordinator, shared_fused_moe, fused_moe_layer, gpu_model_runner

--- a/vllm_metax/patch/dp_fix/gpu_model_runner.py
+++ b/vllm_metax/patch/dp_fix/gpu_model_runner.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import numpy as np
+
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+
+def _metax_reorder_batch_to_split_decodes_and_prefills(
+    input_batch,
+    scheduler_output,
+    decode_threshold: int = 1,
+    group_decodes_by_query_len: bool = False,
+) -> bool:
+    num_reqs = len(input_batch.req_ids)
+    num_scheduled_tokens = [
+        scheduler_output.num_scheduled_tokens[req_id] for req_id in input_batch.req_ids
+    ]
+    num_scheduled_tokens_np = np.array(num_scheduled_tokens, dtype=np.int32)
+    num_computed_tokens_np = input_batch.num_computed_tokens_cpu[:num_reqs]
+
+    is_prefill = num_computed_tokens_np == 0
+    is_decode = (num_scheduled_tokens_np <= decode_threshold) & (~is_prefill)
+    is_extend = (num_scheduled_tokens_np > decode_threshold) & (~is_prefill)
+
+    decode_indices = np.flatnonzero(is_decode)
+    if group_decodes_by_query_len and decode_indices.size > 1:
+        decode_indices = decode_indices[
+            np.argsort(num_scheduled_tokens_np[decode_indices], kind="stable")
+        ]
+    extend_indices = np.flatnonzero(is_extend)
+    prefill_indices = np.flatnonzero(is_prefill)
+    target_order = np.concatenate((decode_indices, extend_indices, prefill_indices))
+
+    if np.array_equal(target_order, np.arange(num_reqs, dtype=np.int64)):
+        return False
+
+    curr_order = np.arange(num_reqs, dtype=np.int32)
+    orig_to_pos = np.arange(num_reqs, dtype=np.int32)
+
+    for dst, src_orig in enumerate(target_order):
+        src = int(orig_to_pos[src_orig])
+        if src == dst:
+            continue
+
+        input_batch.swap_states(dst, src)
+
+        orig_at_dst = int(curr_order[dst])
+        curr_order[dst], curr_order[src] = curr_order[src], curr_order[dst]
+        orig_to_pos[orig_at_dst], orig_to_pos[src_orig] = src, dst
+
+    return True
+
+
+class MacaGPUModelRunner(GPUModelRunner):
+    def _may_reorder_batch(self, scheduler_output: "SchedulerOutput") -> None:
+        if len(self.kv_cache_config.kv_cache_groups) == 0:
+            return
+
+        if self.reorder_batch_threshold is None:
+            return
+
+        spec_decode_enabled = (
+            self.speculative_config is not None
+            and getattr(self, "num_spec_tokens", 0) > 0
+        )
+        if spec_decode_enabled:
+            group_decodes_by_query_len = getattr(
+                self, "_metax_group_decodes_by_query_len", None
+            )
+            if group_decodes_by_query_len is None:
+                group_decodes_by_query_len = any(
+                    getattr(
+                        group.get_metadata_builder(),
+                        "group_decodes_by_query_len",
+                        False,
+                    )
+                    for group in self._attn_group_iterator()
+                )
+                self._metax_group_decodes_by_query_len = group_decodes_by_query_len
+        else:
+            group_decodes_by_query_len = False
+
+        _metax_reorder_batch_to_split_decodes_and_prefills(
+            self.input_batch,
+            scheduler_output,
+            decode_threshold=self.reorder_batch_threshold,
+            group_decodes_by_query_len=group_decodes_by_query_len,
+        )
+
+
+GPUModelRunner._may_reorder_batch = MacaGPUModelRunner._may_reorder_batch

--- a/vllm_metax/v1/attention/backends/flash_attn.py
+++ b/vllm_metax/v1/attention/backends/flash_attn.py
@@ -234,6 +234,9 @@ class FlashAttentionMetadata:
     decode_query_start_loc: torch.Tensor
     decode_seq_lens: torch.Tensor
     decode_block_table: torch.Tensor
+    decode_bucket_query_lens: tuple[int, ...] | None
+    decode_bucket_req_bounds: tuple[tuple[int, int], ...] | None
+    decode_bucket_token_bounds: tuple[tuple[int, int], ...] | None
 
     num_prefills: int
     num_prefill_tokens: int
@@ -276,6 +279,98 @@ def _get_sliding_window_configs(
     return sliding_window_configs
 
 
+def _build_decode_query_len_buckets(
+    query_start_loc_cpu: torch.Tensor,
+    num_decodes: int,
+    num_decode_tokens: int,
+) -> tuple[
+    tuple[int, ...] | None,
+    tuple[tuple[int, int], ...] | None,
+    tuple[tuple[int, int], ...] | None,
+]:
+    """Build contiguous decode buckets keyed by query length."""
+    if num_decodes <= 1:
+        return None, None, None
+
+    decode_query_lens = (
+        query_start_loc_cpu[1 : num_decodes + 1] - query_start_loc_cpu[:num_decodes]
+    ).tolist()
+
+    if num_decode_tokens != sum(decode_query_lens):
+        padded_query_len, remainder = divmod(num_decode_tokens, num_decodes)
+        if remainder != 0 or any(
+            query_len not in (0, padded_query_len) for query_len in decode_query_lens
+        ):
+            raise RuntimeError(
+                "FLASH_ATTN decode bucketing only supports padded decode batches "
+                "when they are padded to a uniform query length."
+            )
+        return None, None, None
+
+    first_query_len = decode_query_lens[0]
+    if all(query_len == first_query_len for query_len in decode_query_lens):
+        return None, None, None
+
+    bucket_query_lens: list[int] = []
+    bucket_req_bounds: list[tuple[int, int]] = []
+    bucket_token_bounds: list[tuple[int, int]] = []
+    run_start: int | None = None
+    run_query_len: int | None = None
+
+    for req_idx, query_len_value in enumerate(decode_query_lens):
+        query_len = int(query_len_value)
+        if query_len == 0:
+            if run_start is not None and run_query_len is not None:
+                bucket_query_lens.append(run_query_len)
+                bucket_req_bounds.append((run_start, req_idx))
+                bucket_token_bounds.append(
+                    (
+                        int(query_start_loc_cpu[run_start].item()),
+                        int(query_start_loc_cpu[req_idx].item()),
+                    )
+                )
+                run_start = None
+                run_query_len = None
+            continue
+
+        if run_start is None:
+            run_start = req_idx
+            run_query_len = query_len
+            continue
+
+        if query_len != run_query_len:
+            assert run_query_len is not None
+            bucket_query_lens.append(run_query_len)
+            bucket_req_bounds.append((run_start, req_idx))
+            bucket_token_bounds.append(
+                (
+                    int(query_start_loc_cpu[run_start].item()),
+                    int(query_start_loc_cpu[req_idx].item()),
+                )
+            )
+            run_start = req_idx
+            run_query_len = query_len
+
+    if run_start is not None and run_query_len is not None:
+        bucket_query_lens.append(run_query_len)
+        bucket_req_bounds.append((run_start, num_decodes))
+        bucket_token_bounds.append(
+            (
+                int(query_start_loc_cpu[run_start].item()),
+                int(query_start_loc_cpu[num_decodes].item()),
+            )
+        )
+
+    if not bucket_query_lens:
+        return None, None, None
+
+    return (
+        tuple(bucket_query_lens),
+        tuple(bucket_req_bounds),
+        tuple(bucket_token_bounds),
+    )
+
+
 class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetadata]):
     # /------------------------  Metax Modification -------------------------\
     _cudagraph_support = AttentionCGSupport.UNIFORM_BATCH
@@ -287,6 +382,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     # If set to UNIFORM or VARLEN, this will increase `reorder_batch_threshold` when
     # speculative decoding is enabled.
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+    group_decodes_by_query_len: bool = True
 
     # The threshold for reordering the batch into decode and prefill requests.
     # If > 1, the batch will be reordered such that requests with
@@ -332,6 +428,18 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         self.aot_schedule = get_flash_attn_version() == 3
 
         # /------------------------  Metax Modification -------------------------\
+        speculative_config = self.vllm_config.speculative_config
+        spec_decode_enabled = (
+            speculative_config is not None
+            and speculative_config.num_speculative_tokens is not None
+            and speculative_config.num_speculative_tokens > 0
+        )
+        self.query_len_support = (
+            QueryLenSupport.VARLEN
+            if spec_decode_enabled
+            else QueryLenSupport.UNIFORM
+        )
+        self.group_decodes_by_query_len = spec_decode_enabled
         supports_spec_decode = self.query_len_support != QueryLenSupport.SINGLE_ONLY
         self._init_reorder_batch_threshold(
             self.reorder_batch_threshold, supports_spec_decode
@@ -478,10 +586,27 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             decode_block_table_tensor = common_attn_metadata.block_table_tensor[
                 :num_decodes
             ]
+            if self.group_decodes_by_query_len:
+                (
+                    decode_bucket_query_lens,
+                    decode_bucket_req_bounds,
+                    decode_bucket_token_bounds,
+                ) = _build_decode_query_len_buckets(
+                    common_attn_metadata.query_start_loc_cpu,
+                    num_decodes,
+                    num_decode_tokens,
+                )
+            else:
+                decode_bucket_query_lens = None
+                decode_bucket_req_bounds = None
+                decode_bucket_token_bounds = None
         else:
             decode_query_start_loc = None
             decode_seq_lens = None
             decode_block_table_tensor = None
+            decode_bucket_query_lens = None
+            decode_bucket_req_bounds = None
+            decode_bucket_token_bounds = None
 
         if num_prefills > 0:
             prefill_query_start_loc = (
@@ -662,6 +787,9 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             decode_query_start_loc=decode_query_start_loc,
             decode_seq_lens=decode_seq_lens,
             decode_block_table=decode_block_table_tensor,
+            decode_bucket_query_lens=decode_bucket_query_lens,
+            decode_bucket_req_bounds=decode_bucket_req_bounds,
+            decode_bucket_token_bounds=decode_bucket_token_bounds,
             num_prefills=num_prefills,
             num_prefill_tokens=num_prefill_tokens,
             prefill_query_start_loc=prefill_query_start_loc,
@@ -694,13 +822,13 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     ) -> FlashAttentionMetadata:
         new_metadata = copy.copy(metadata)
         new_metadata.block_table = blk_table
-        new_metadata.prefill_block_table = (
-            blk_table[metadata.num_decodes :] if metadata.num_prefills > 0 else None
-        )
-        new_metadata.decode_block_table = (
-            blk_table[: metadata.num_decodes] if metadata.num_decodes > 0 else None
-        )
         new_metadata.slot_mapping = slot_mapping
+        if metadata.num_decodes > 0:
+            new_metadata.decode_block_table = blk_table[: metadata.num_decodes]
+        if metadata.num_prefills > 0:
+            new_metadata.prefill_block_table = blk_table[
+                metadata.num_decodes : metadata.num_decodes + metadata.num_prefills
+            ]
         return new_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:
@@ -775,6 +903,60 @@ class FlashAttentionImpl(AttentionImpl):
             )
 
         self.supports_quant_query_input = False
+
+    def _forward_decode_with_query_len_bucketing(
+        self,
+        query: torch.Tensor,
+        key_cache: torch.Tensor,
+        value_cache: torch.Tensor,
+        output: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+    ) -> None:
+        assert attn_metadata.decode_query_start_loc is not None
+        assert attn_metadata.decode_seq_lens is not None
+        assert attn_metadata.decode_block_table is not None
+        assert attn_metadata.decode_bucket_query_lens is not None
+        assert attn_metadata.decode_bucket_req_bounds is not None
+        assert attn_metadata.decode_bucket_token_bounds is not None
+
+        decode_query = query[: attn_metadata.num_decode_tokens]
+        decode_output = output[: attn_metadata.num_decode_tokens]
+
+        for bucket_query_len, bucket_req_bounds, bucket_token_bounds in zip(
+            attn_metadata.decode_bucket_query_lens,
+            attn_metadata.decode_bucket_req_bounds,
+            attn_metadata.decode_bucket_token_bounds,
+        ):
+            req_start, req_end = bucket_req_bounds
+            token_start, token_end = bucket_token_bounds
+            if req_start == req_end or token_start == token_end:
+                continue
+
+            bucket_query = decode_query[token_start:token_end].view(
+                req_end - req_start,
+                bucket_query_len,
+                decode_query.shape[1],
+                decode_query.shape[2],
+            )
+
+            bucket_output = flash_attn_with_kvcache(
+                q=bucket_query,
+                k_cache=key_cache,
+                v_cache=value_cache,
+                block_table=attn_metadata.decode_block_table[req_start:req_end],
+                cache_seqlens=attn_metadata.decode_seq_lens[req_start:req_end],
+                softmax_scale=self.scale,
+                causal=True,
+                window_size=list(self.sliding_window)
+                if self.sliding_window is not None
+                else None,
+                alibi_slopes=self.alibi_slopes,
+                softcap=self.logits_soft_cap,
+                s_aux=self.sinks,
+            )
+            decode_output[token_start:token_end] = (
+                reshape_attn_output_for_spec_decode(bucket_output)
+            )
 
     def forward(
         self,
@@ -913,26 +1095,35 @@ class FlashAttentionImpl(AttentionImpl):
                         )
                     if attn_metadata.num_decodes > 0:
                         # Use flash_attn_with_kvcache for normal decoding.
-                        decode_query = query[:num_decode_tokens]
-                        decode_query = reshape_query_for_spec_decode(
-                            decode_query, attn_metadata.num_decodes
-                        )
-                        output_unreshape = flash_attn_with_kvcache(
-                            q=decode_query,
-                            k_cache=key_cache,
-                            v_cache=value_cache,
-                            block_table=attn_metadata.decode_block_table,
-                            cache_seqlens=attn_metadata.decode_seq_lens,
-                            softmax_scale=self.scale,
-                            causal=True,
-                            window_size=sliding_window_size,
-                            alibi_slopes=self.alibi_slopes,
-                            softcap=self.logits_soft_cap,
-                            s_aux=self.sinks,
-                        )
-                        output[:num_decode_tokens] = (
-                            reshape_attn_output_for_spec_decode(output_unreshape)
-                        )
+                        if attn_metadata.decode_bucket_req_bounds is not None:
+                            self._forward_decode_with_query_len_bucketing(
+                                query,
+                                key_cache,
+                                value_cache,
+                                output,
+                                attn_metadata,
+                            )
+                        else:
+                            decode_query = query[:num_decode_tokens]
+                            decode_query = reshape_query_for_spec_decode(
+                                decode_query, attn_metadata.num_decodes
+                            )
+                            output_unreshape = flash_attn_with_kvcache(
+                                q=decode_query,
+                                k_cache=key_cache,
+                                v_cache=value_cache,
+                                block_table=attn_metadata.decode_block_table,
+                                cache_seqlens=attn_metadata.decode_seq_lens,
+                                softmax_scale=self.scale,
+                                causal=True,
+                                window_size=sliding_window_size,
+                                alibi_slopes=self.alibi_slopes,
+                                softcap=self.logits_soft_cap,
+                                s_aux=self.sinks,
+                            )
+                            output[:num_decode_tokens] = (
+                                reshape_attn_output_for_spec_decode(output_unreshape)
+                            )
                     return output
                 # └------------------------- Metax Modification -------------------------┘
                 else:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Optimize variable-length speculative decode performance for MetaX FlashAttention by:
- grouping speculative decode requests by query length
- preserving the original fast path for normal decode
- adding query-length-aware batch reordering in the GPU model runner

<summary>main</summary>

```text
============ Serving Benchmark Result ============
Successful requests:                     4
Failed requests:                         0
Maximum request concurrency:             2
Benchmark duration (s):                  663.05
Total input tokens:                      409600
Total generated tokens:                  4096
Request throughput (req/s):              0.01
Output token throughput (tok/s):         6.18
Peak output token throughput (tok/s):    22.00
Peak concurrent requests:                3.00
Total token throughput (tok/s):          623.93
---------------Time to First Token----------------
Mean TTFT (ms):                          28023.24
Median TTFT (ms):                        23907.75
P99 TTFT (ms):                           42220.16
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          293.35
Median TPOT (ms):                        294.05
P99 TPOT (ms):                           352.08
---------------Inter-token Latency----------------
Mean ITL (ms):                           456.25
Median ITL (ms):                         684.87
P99 ITL (ms):                            697.84
----------------End-to-end Latency----------------
Mean E2EL (ms):                          328123.81
Median E2EL (ms):                        324721.69
P99 E2EL (ms):                           402400.33
----------------Speculative Decoding---------------
Acceptance rate (%):                    24.52
Acceptance length:                      1.84
Drafts:                                 1745
Draft tokens:                           6008
Accepted tokens:                        1473
==================================================
```




<summary>PR</summary>

```text
============ Serving Benchmark Result ============
Successful requests:                     4
Failed requests:                         0
Maximum request concurrency:             2
Benchmark duration (s):                  142.67
Total input tokens:                      409600
Total generated tokens:                  4096
Request throughput (req/s):              0.03
Output token throughput (tok/s):         28.71
Peak output token throughput (tok/s):    42.00
Peak concurrent requests:                3.00
Total token throughput (tok/s):          2899.67
---------------Time to First Token----------------
Mean TTFT (ms):                          24895.49
Median TTFT (ms):                        21196.31
P99 TTFT (ms):                           37379.07
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          44.48
Median TPOT (ms):                        49.03
P99 TPOT (ms):                           57.88
---------------Inter-token Latency----------------
Mean ITL (ms):                           73.04
Median ITL (ms):                         54.26
P99 ITL (ms):                            65.45
----------------End-to-end Latency----------------
Mean E2EL (ms):                          70399.34
Median E2EL (ms):                        71334.00
P99 E2EL (ms):                           96483.96
----------------Speculative Decoding---------------
Acceptance rate (%):                    28.31
Acceptance length:                      2.03
Drafts:                                 1563
==================================================
```

## Correctness

<summary>CEval</summary>

| Model | Dataset | Metric | Subject | Count | Score | Category |
| --- | --- | --- | --- | ---: | ---: | --- |
| MiniMax-M2.5 | ceval | mean_acc | business_administration | 33 | 0.8485 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | marxism | 19 | 0.8421 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | mao_zedong_thought | 24 | 0.8750 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | education_science | 29 | 0.8621 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | teacher_qualification | 44 | 0.9545 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | high_school_politics | 19 | 0.9474 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | high_school_geography | 19 | 0.8421 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | middle_school_politics | 21 | 1.0000 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | middle_school_geography | 12 | 0.9167 | Social Science |
| MiniMax-M2.5 | ceval | mean_acc | OVERALL | 1346 | 0.8529 | - |
