### PR TITLE
[Bugfix] Fix type annotation forward reference

### DIFF
--- a/vllm_metax/platform.py
+++ b/vllm_metax/platform.py
@@ -52,7 +52,7 @@ def _get_backend_priorities(
     use_mla: bool,
     device_capability: DeviceCapability,
     num_heads: int | None = None,
-    kv_cache_dtype: CacheDType | None = None,
+    kv_cache_dtype: "CacheDType | None" = None,
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
     from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -570,7 +570,7 @@ class MacaPlatformBase(Platform):
 
     @classmethod
     def support_deep_gemm(cls) -> bool:
-        return True
+        return False
 
     @classmethod
     def num_compute_units(cls, device_id=0) -> int:


### PR DESCRIPTION
# vllm serve command
vllm serve /external/models/Qwen3-0.6B

# Error log

## DeepGemm 
<img width="1692" height="197" alt="image" src="https://github.com/user-attachments/assets/c66a9986-8d06-478c-a379-83d8faf2cc26" />

## type annotation
<img width="1137" height="180" alt="image" src="https://github.com/user-attachments/assets/c9cd0979-ce5e-438e-abb1-a8687b4e561a" />

