### PR TITLE
[Bugfix] Register GGUF (ggml) ops so `--quantization gguf` works

### DIFF
--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -373,6 +373,39 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gptq_shuffle(Tensor! q_weight, Tensor q_perm, int bit) -> ()");
   ops.impl("gptq_shuffle", torch::kCUDA, &gptq_shuffle);
 
+  // Dequantization for GGML.
+  ops.def(
+      "ggml_dequantize(Tensor W, int type, SymInt m, SymInt n, ScalarType? "
+      "dtype) -> Tensor");
+  ops.impl("ggml_dequantize", torch::kCUDA, &ggml_dequantize);
+
+  // mmvq kernel for GGML.
+  ops.def(
+      "ggml_mul_mat_vec_a8(Tensor W, Tensor X, int type, SymInt row) -> Tensor");
+  ops.impl("ggml_mul_mat_vec_a8", torch::kCUDA, &ggml_mul_mat_vec_a8);
+
+  // mmq kernel for GGML.
+  ops.def("ggml_mul_mat_a8(Tensor W, Tensor X, int type, SymInt row) -> Tensor");
+  ops.impl("ggml_mul_mat_a8", torch::kCUDA, &ggml_mul_mat_a8);
+
+  // mmq kernel for GGML (MoE).
+  ops.def(
+      "ggml_moe_a8(Tensor X, Tensor W, "
+      "Tensor sorted_token_ids, Tensor expert_ids, "
+      "Tensor num_tokens_post_padded, int type, "
+      "SymInt row, SymInt top_k, SymInt tokens) -> Tensor");
+  ops.impl("ggml_moe_a8", torch::kCUDA, &ggml_moe_a8);
+
+  // mmvq kernel for GGML (MoE).
+  ops.def(
+      "ggml_moe_a8_vec(Tensor X, Tensor W, "
+      "Tensor topk_ids, int top_k, "
+      "int type, SymInt row, SymInt tokens) -> Tensor");
+  ops.impl("ggml_moe_a8_vec", torch::kCUDA, &ggml_moe_a8_vec);
+
+  ops.def("ggml_moe_get_block_size(int type) -> int");
+  ops.impl("ggml_moe_get_block_size", &ggml_moe_get_block_size);
+
   // ┌----------  Not supported for Metax -----------┐
   // Compute FP8 quantized tensor for given scaling factor.
   // Supports per-tensor, per-channel, per-token, and arbitrary 2D group


### PR DESCRIPTION
Fixes #262.

## Problem
`--quantization gguf` fails on vllm-metax:
```
AttributeError: '_OpNamespace' '_C' object has no attribute 'ggml_dequantize'.
Did you mean: 'awq_dequantize'?
```
`csrc/quantization/gguf/gguf_kernel.cu` is compiled into `_C` (it's in `CMakeLists.txt`) and `csrc/ops.h` declares all six `ggml_*` functions — but `csrc/torch_bindings.cpp` never registered them. AWQ/GPTQ register both symbol **and** schema; ggml only had the symbol, so `torch.ops._C.ggml_dequantize` doesn't exist.

## Fix
Add the `ggml_*` `ops.def`/`ops.impl` block (matching upstream vLLM) after the GPTQ registrations. No kernel changes — the kernels were already built.

## Validation
On MetaX C500 (MACA 3.5.3.20, torch 2.8), `releases/v0.17.0`, from-source build (`USE_PRECOMPILED_KERNEL=0`):

| | before | after |
|---|---|---|
| `torch.ops._C.ggml_dequantize` | missing | registered |
| `--quantization gguf` load | crashes | works |

`Qwen2.5-0.5B-Instruct-GGUF` (q4_k_m) loads and generates coherent output (EN + ZH) after the fix.

## Note for maintainers
The default runtime (`USE_PRECOMPILED_KERNEL=1`) loads the precompiled **`mcoplib`** package, which has the **same** missing registration. This source fix only reaches the `USE_PRECOMPILED_KERNEL=0` build — **`mcoplib` needs the same `ggml_*` registration restored** for the default path. (The kernels are already in `mcoplib`; only the `TORCH_LIBRARY` registration is missing.)
