### PR TITLE
[BugFix] guard mctlass W8A8 scaled_mm shape

### DIFF
--- a/tests/kernels/quantization/test_mctlass_scaled_mm_shape.py
+++ b/tests/kernels/quantization/test_mctlass_scaled_mm_shape.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+ops = pytest.importorskip(
+    "vllm_metax.model_executor.layers.quantization._python_api_ops",
+    reason="mctlassEx / MetaX backend not available",
+)
+
+
+class _TensorShape:
+    def __init__(self, shape):
+        self.shape = shape
+
+
+@pytest.mark.parametrize(
+    ("a_shape", "out_shape"),
+    [
+        ((4, 24), (4, 16)),
+        ((4, 16), (4, 24)),
+        ((4, 24), (4, 24)),
+    ],
+)
+def test_mctlass_w8a8_scaled_mm_rejects_unaligned_shape(
+    a_shape, out_shape,
+):
+    with pytest.raises(ValueError, match="K and N to be multiples of 16"):
+        ops._check_mctlass_w8a8_scaled_mm_shape(
+            _TensorShape(a_shape), _TensorShape(out_shape)
+        )
+
+
+def test_mctlass_w8a8_scaled_mm_accepts_aligned_shape():
+    ops._check_mctlass_w8a8_scaled_mm_shape(
+        _TensorShape((4, 16)), _TensorShape((4, 32))
+    )

--- a/vllm_metax/model_executor/layers/quantization/_python_api_ops.py
+++ b/vllm_metax/model_executor/layers/quantization/_python_api_ops.py
@@ -134,6 +134,19 @@ with contextlib.suppress(ImportError):
             )
 
 
+def _check_mctlass_w8a8_scaled_mm_shape(
+    a: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    k = a.shape[-1]
+    n = out.shape[-1]
+    if k % 16 != 0 or n % 16 != 0:
+        raise ValueError(
+            "mctlassEx W8A8 scaled_mm requires K and N to be multiples of 16, "
+            f"but got K={k}, N={n}"
+        )
+
+
 # w8a8 scaled mm
 def mctlassEx_w8a8_scaled_mm_azp(
     out: torch.Tensor,
@@ -147,6 +160,8 @@ def mctlassEx_w8a8_scaled_mm_azp(
 ) -> torch.Tensor:
     if bias is not None and bias.dim() == 1:
         bias = bias.unsqueeze(0)
+
+    _check_mctlass_w8a8_scaled_mm_shape(a, out)
 
     if azp is not None or azp_adj is not None or bias is not None:
         assert mctlass_scaled_gemm is not None, (


### PR DESCRIPTION
## Purpose

Add a Python-side shape guard for the mctlassEx W8A8 `scaled_mm` path.

The mctlass W8A8 kernel requires both `K` and `N` to be multiples of 16. A
misaligned `K` currently fails before device memory is touched, but a
misaligned `N` can trigger a device-side memory violation and poison the MACA
runtime for the rest of the process. This patch rejects those shapes before
calling into mctlassEx.

## Test Plan

- `python3 -m py_compile vllm_metax/model_executor/layers/quantization/_python_api_ops.py tests/kernels/quantization/test_mctlass_scaled_mm_shape.py`
- `/opt/conda/bin/python -m py_compile vllm_metax/model_executor/layers/quantization/_python_api_ops.py tests/kernels/quantization/test_mctlass_scaled_mm_shape.py`
- Light helper check for aligned and unaligned `(K, N)` shapes.

Full pytest was not run on this rental image because the checked-out source and
installed `/opt/conda` vLLM package are out of sync (`vllm.v1.attention...mla`
import path mismatch), and the repo-level `tests/conftest.py` also requires
`tblib` which is not installed in this image.

## Context

This follows the shape issue observed while adding the real-GPU W8A8 scaled_mm
coverage in #268: the safe behavior is to fail at the wrapper boundary instead
of letting invalid `N` reach the device kernel.
