### PR TITLE
增加沐曦运行环境预检工具

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ Homepage="https://github.com/MetaX-MACA/vLLM-metax"
 
 [project.scripts]
 vllm_collect_env = "vllm_metax:collect_env"
+vllm_metax_preflight = "vllm_metax.preflight:main"
 
 [project.entry-points."vllm.platform_plugins"]
 metax = "vllm_metax:register"

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from vllm_metax.preflight import collect_preflight
+from vllm_metax.preflight import _run_version, collect_preflight
 
 
 def _make_executable(path: Path) -> None:
@@ -36,6 +36,19 @@ def test_preflight_finds_sdk_local_tools(tmp_path):
     assert info["commands"]["mxcc"].endswith("mxcc")
     assert info["commands"]["cucc"].endswith("cucc")
     assert info["commands"]["nvcc"].endswith("nvcc")
+
+
+def test_run_version_returns_none_for_empty_output():
+    with patch("subprocess.check_output", return_value=""):
+        assert _run_version(["cucc", "--version"]) is None
+
+
+def test_preflight_does_not_probe_current_directory_when_paths_are_missing():
+    with patch.dict(os.environ, {}, clear=True):
+        info = collect_preflight()
+
+    assert info["commands"]["cucc"] is None
+    assert info["commands"]["nvcc"] is None
 
 
 if __name__ == "__main__":

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -29,7 +29,14 @@ def test_preflight_finds_sdk_local_tools(tmp_path):
     _make_executable(cu_bridge / "CUDA_DIR" / "bin" / "nvcc")
 
     path = os.pathsep.join([str(maca / "bin"), os.environ.get("PATH", "")])
-    with patch.dict(os.environ, {"MACA_PATH": str(maca), "PATH": path}, clear=True):
+    env_patch = {
+        "MACA_PATH": str(maca),
+        "PATH": path,
+        "MACA_HOME": "",
+        "CUCC_PATH": "",
+        "CUDA_PATH": "",
+    }
+    with patch.dict(os.environ, env_patch):
         info = collect_preflight()
 
     assert info["maca_version"] == "MACA Version: 2.33.1"
@@ -44,7 +51,10 @@ def test_run_version_returns_none_for_empty_output():
 
 
 def test_preflight_does_not_probe_current_directory_when_paths_are_missing():
-    with patch.dict(os.environ, {}, clear=True):
+    with patch.dict(
+        os.environ,
+        {"MACA_PATH": "", "MACA_HOME": "", "CUCC_PATH": "", "CUDA_PATH": ""},
+    ):
         info = collect_preflight()
 
     assert info["commands"]["cucc"] is None

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,45 @@
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from vllm_metax.preflight import collect_preflight
+
+
+def _make_executable(path: Path) -> None:
+    path.write_text("#!/bin/sh\necho fake-version\n", encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
+def test_preflight_finds_sdk_local_tools(tmp_path):
+    maca = tmp_path / "maca"
+    cu_bridge = maca / "tools" / "cu-bridge"
+    for directory in [
+        maca / "bin",
+        cu_bridge / "bin",
+        cu_bridge / "CUDA_DIR" / "bin",
+    ]:
+        directory.mkdir(parents=True)
+    (maca / "Version.txt").write_text("MACA Version: 2.33.1\n", encoding="utf-8")
+    _make_executable(maca / "bin" / "mxcc")
+    _make_executable(cu_bridge / "bin" / "cucc")
+    _make_executable(cu_bridge / "CUDA_DIR" / "bin" / "nvcc")
+
+    path = os.pathsep.join([str(maca / "bin"), os.environ.get("PATH", "")])
+    with patch.dict(os.environ, {"MACA_PATH": str(maca), "PATH": path}, clear=True):
+        info = collect_preflight()
+
+    assert info["maca_version"] == "MACA Version: 2.33.1"
+    assert info["commands"]["mxcc"].endswith("mxcc")
+    assert info["commands"]["cucc"].endswith("cucc")
+    assert info["commands"]["nvcc"].endswith("nvcc")
+
+
+if __name__ == "__main__":
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        test_preflight_finds_sdk_local_tools(Path(tmpdir))

--- a/vllm_metax/preflight.py
+++ b/vllm_metax/preflight.py
@@ -18,9 +18,11 @@ def _first_existing(paths: list[Path]) -> Path | None:
 
 def _run_version(command: list[str]) -> str | None:
     try:
-        return subprocess.check_output(
+        output = subprocess.check_output(
             command, stderr=subprocess.STDOUT, text=True, timeout=10
-        ).splitlines()[0]
+        )
+        lines = output.splitlines()
+        return lines[0] if lines else None
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
         return None
 
@@ -43,11 +45,13 @@ def collect_preflight() -> dict[str, object]:
         "mxcc": shutil.which("mxcc"),
         "cucc": _first_existing(
             [
-                Path(cucc_path or "") / "bin" / "cucc",
-                Path(cucc_path or "") / "tools" / "cucc",
+                Path(cucc_path) / "bin" / "cucc",
+                Path(cucc_path) / "tools" / "cucc",
             ]
-        ),
-        "nvcc": _first_existing([Path(cuda_path or "") / "bin" / "nvcc"]),
+        )
+        if cucc_path
+        else None,
+        "nvcc": _first_existing([Path(cuda_path) / "bin" / "nvcc"]) if cuda_path else None,
     }
     normalized_commands = {
         name: str(value) if value else None for name, value in commands.items()
@@ -58,14 +62,19 @@ def collect_preflight() -> dict[str, object]:
         if normalized_commands.get(name) is None
     ]
 
+    maca_version = None
+    if version_file and version_file.is_file():
+        try:
+            maca_version = version_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            maca_version = None
+
     info: dict[str, object] = {
         "python": sys.version.replace("\n", " "),
         "maca_path": maca_path,
         "cucc_path": cucc_path,
         "cuda_path": cuda_path,
-        "maca_version": version_file.read_text(encoding="utf-8").strip()
-        if version_file and version_file.is_file()
-        else None,
+        "maca_version": maca_version,
         "commands": normalized_commands,
         "command_versions": {
             name: _run_version([path, "--version"])

--- a/vllm_metax/preflight.py
+++ b/vllm_metax/preflight.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _first_existing(paths: list[Path]) -> Path | None:
+    for path in paths:
+        if path.exists():
+            return path
+    return None
+
+
+def _run_version(command: list[str]) -> str | None:
+    try:
+        return subprocess.check_output(
+            command, stderr=subprocess.STDOUT, text=True, timeout=10
+        ).splitlines()[0]
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+
+
+def collect_preflight() -> dict[str, object]:
+    maca_path = os.environ.get("MACA_PATH") or os.environ.get("MACA_HOME")
+    cucc_path = os.environ.get("CUCC_PATH")
+    if not cucc_path and maca_path:
+        cucc_path = str(Path(maca_path) / "tools" / "cu-bridge")
+
+    version_file = Path(maca_path) / "Version.txt" if maca_path else None
+    cuda_path = os.environ.get("CUDA_PATH")
+    if not cuda_path and cucc_path:
+        cuda_path_candidate = Path(cucc_path) / "CUDA_DIR"
+        cuda_path = str(cuda_path_candidate if cuda_path_candidate.exists() else Path(cucc_path))
+
+    commands = {
+        "cmake_maca": shutil.which("cmake_maca"),
+        "cmake": shutil.which("cmake"),
+        "mxcc": shutil.which("mxcc"),
+        "cucc": _first_existing(
+            [
+                Path(cucc_path or "") / "bin" / "cucc",
+                Path(cucc_path or "") / "tools" / "cucc",
+            ]
+        ),
+        "nvcc": _first_existing([Path(cuda_path or "") / "bin" / "nvcc"]),
+    }
+    normalized_commands = {
+        name: str(value) if value else None for name, value in commands.items()
+    }
+    missing = [
+        name
+        for name in ("cmake_maca", "mxcc", "cucc", "nvcc")
+        if normalized_commands.get(name) is None
+    ]
+
+    info: dict[str, object] = {
+        "python": sys.version.replace("\n", " "),
+        "maca_path": maca_path,
+        "cucc_path": cucc_path,
+        "cuda_path": cuda_path,
+        "maca_version": version_file.read_text(encoding="utf-8").strip()
+        if version_file and version_file.is_file()
+        else None,
+        "commands": normalized_commands,
+        "command_versions": {
+            name: _run_version([path, "--version"])
+            for name, path in normalized_commands.items()
+            if path
+        },
+        "missing": missing,
+        "ok": not missing and bool(maca_path),
+    }
+    try:
+        import torch
+
+        info["torch"] = {
+            "version": torch.__version__,
+            "cuda": torch.version.cuda,
+            "cuda_available": torch.cuda.is_available(),
+        }
+    except Exception as err:
+        info["torch"] = {"error": str(err)}
+    return info
+
+
+def main() -> int:
+    info = collect_preflight()
+    print(json.dumps(info, indent=2, sort_keys=True))
+    return 0 if info["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
该 PR 为 vLLM-metax 增加独立的 MACA 环境预检入口，用于在启动推理前检查关键环境变量、运行时路径和编译工具是否可用，减少用户等到模型加载或算子初始化阶段才发现环境缺失的问题。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/add-maca-preflight-tool`，目标仓库：`MetaX-MACA/vLLM-metax`。