### PR TITLE
采集 cucc 编译器版本信息

### DIFF
--- a/tests/test_collect_env_compiler.py
+++ b/tests/test_collect_env_compiler.py
@@ -32,6 +32,31 @@ class TestCollectEnvCompilerVersion(unittest.TestCase):
         self.assertLess(commands.index(["cucc", "--version"]), commands.index(["nvcc", "--version"]))
         self.assertEqual(commands[-1], ["nvcc", "--version"])
 
+    def test_expands_compiler_paths_from_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "HOME": "/workspace/user",
+                "USERPROFILE": "/workspace/user",
+                "CUCC_PATH": "$HOME/cu-bridge",
+                "MACA_PATH": "~/maca-sdk",
+            },
+            clear=True,
+        ):
+            commands = get_cuda_compiler_version_commands()
+
+        self.assertEqual(
+            commands[0],
+            [os.path.join("/workspace/user/cu-bridge", "bin", "cucc"), "--version"],
+        )
+        self.assertEqual(
+            commands[1],
+            [
+                os.path.join("/workspace/user/maca-sdk", "tools", "cu-bridge", "bin", "cucc"),
+                "--version",
+            ],
+        )
+
     def test_reads_first_available_compiler_version(self):
         calls = []
 

--- a/tests/test_collect_env_compiler.py
+++ b/tests/test_collect_env_compiler.py
@@ -1,0 +1,57 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from vllm_metax.collect_env import (
+    get_cuda_compiler_version_commands,
+    get_running_cuda_version,
+)
+
+
+class TestCollectEnvCompilerVersion(unittest.TestCase):
+
+    def test_prefers_maca_cucc_before_nvcc(self):
+        with patch.dict(
+            os.environ,
+            {
+                "CUCC_PATH": "/opt/maca/tools/cu-bridge",
+                "MACA_PATH": "/opt/maca",
+            },
+            clear=True,
+        ):
+            commands = get_cuda_compiler_version_commands()
+
+        self.assertEqual(
+            commands[0],
+            [
+                os.path.join("/opt/maca/tools/cu-bridge", "bin", "cucc"),
+                "--version",
+            ],
+        )
+        self.assertIn(["cucc", "--version"], commands)
+        self.assertLess(commands.index(["cucc", "--version"]), commands.index(["nvcc", "--version"]))
+        self.assertEqual(commands[-1], ["nvcc", "--version"])
+
+    def test_reads_first_available_compiler_version(self):
+        calls = []
+
+        def fake_run(command):
+            calls.append(command)
+            if command == ["cucc", "--version"]:
+                return (
+                    0,
+                    "Cuda compilation tools, release 12.1, V12.1.105",
+                    "",
+                )
+            return 127, "", "not found"
+
+        with patch.dict(os.environ, {}, clear=True):
+            version = get_running_cuda_version(fake_run)
+
+        self.assertEqual(version, "12.1.105")
+        self.assertIn(["cucc", "--version"], calls)
+        self.assertNotIn(["nvcc", "--version"], calls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -229,10 +229,12 @@ def get_cuda_compiler_version_commands():
 
     cucc_path = os.environ.get("CUCC_PATH")
     if cucc_path:
+        cucc_path = os.path.expanduser(os.path.expandvars(cucc_path))
         add_command([os.path.join(cucc_path, "bin", "cucc"), "--version"])
 
     maca_path = os.environ.get("MACA_PATH")
     if maca_path:
+        maca_path = os.path.expanduser(os.path.expandvars(maca_path))
         add_command(
             [
                 os.path.join(maca_path, "tools", "cu-bridge", "bin", "cucc"),

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -216,8 +216,41 @@ def get_gpu_info(run_lambda):
     return re.sub(uuid_regex, "", out)
 
 
+def get_cuda_compiler_version_commands():
+    commands = []
+    seen = set()
+
+    def add_command(command):
+        key = tuple(command) if isinstance(command, list) else command
+        if key in seen:
+            return
+        seen.add(key)
+        commands.append(command)
+
+    cucc_path = os.environ.get("CUCC_PATH")
+    if cucc_path:
+        add_command([os.path.join(cucc_path, "bin", "cucc"), "--version"])
+
+    maca_path = os.environ.get("MACA_PATH")
+    if maca_path:
+        add_command(
+            [
+                os.path.join(maca_path, "tools", "cu-bridge", "bin", "cucc"),
+                "--version",
+            ]
+        )
+
+    add_command(["cucc", "--version"])
+    add_command(["nvcc", "--version"])
+    return commands
+
+
 def get_running_cuda_version(run_lambda):
-    return run_and_parse_first_match(run_lambda, "nvcc --version", r"release .+ V(.*)")
+    for command in get_cuda_compiler_version_commands():
+        version = run_and_parse_first_match(run_lambda, command, r"release .+ V(.*)")
+        if version is not None:
+            return version
+    return None
 
 
 def get_maca_sdk_version(run_lambda):


### PR DESCRIPTION
该 PR 扩展环境采集逻辑，自动记录 cucc 编译器版本，方便定位不同沐曦工具链版本下的构建和运行差异。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/collect-cucc-version`，目标仓库：`MetaX-MACA/vLLM-metax`。