### PR TITLE
支持环境信息 JSON 输出

### DIFF
--- a/tests/test_collect_env_json.py
+++ b/tests/test_collect_env_json.py
@@ -1,36 +1,21 @@
-import ast
 import json
-from collections import namedtuple
 from pathlib import Path
+import sys
+from unittest.mock import patch
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-def _load_json_helper():
-    source_path = Path(__file__).resolve().parents[1] / "vllm_metax" / "collect_env.py"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            isinstance(node, ast.Import)
-            and any(alias.name == "json" for alias in node.names)
-        )
-        or (isinstance(node, ast.FunctionDef) and node.name == "get_json_env_info")
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace
+from vllm_metax.collect_env import SystemEnv, get_json_env_info
 
 
 def test_collect_env_json_uses_namedtuple_fields():
-    namespace = _load_json_helper()
-    env_type = namedtuple("SystemEnv", ["maca_sdk_version", "torch_version"])
-    namespace["get_env_info"] = lambda: env_type("2.33.1", "2.8.0")
+    dummy_data = {field: f"mock_{field}" for field in SystemEnv._fields}
+    mock_env = SystemEnv(**dummy_data)
 
-    data = json.loads(namespace["get_json_env_info"]())
+    with patch("vllm_metax.collect_env.get_env_info", return_value=mock_env):
+        data = json.loads(get_json_env_info())
 
-    assert data == {"maca_sdk_version": "2.33.1", "torch_version": "2.8.0"}
+    assert data == dummy_data
 
 
 if __name__ == "__main__":

--- a/tests/test_collect_env_json.py
+++ b/tests/test_collect_env_json.py
@@ -1,0 +1,37 @@
+import ast
+import json
+from collections import namedtuple
+from pathlib import Path
+
+
+def _load_json_helper():
+    source_path = Path(__file__).resolve().parents[1] / "vllm_metax" / "collect_env.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Import)
+            and any(alias.name == "json" for alias in node.names)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name == "get_json_env_info")
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace
+
+
+def test_collect_env_json_uses_namedtuple_fields():
+    namespace = _load_json_helper()
+    env_type = namedtuple("SystemEnv", ["maca_sdk_version", "torch_version"])
+    namespace["get_env_info"] = lambda: env_type("2.33.1", "2.8.0")
+
+    data = json.loads(namespace["get_json_env_info"]())
+
+    assert data == {"maca_sdk_version": "2.33.1", "torch_version": "2.8.0"}
+
+
+if __name__ == "__main__":
+    test_collect_env_json_uses_namedtuple_fields()

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -5,7 +5,9 @@
 # ruff: noqa
 # code borrowed from https://github.com/pytorch/pytorch/blob/main/torch/utils/collect_env.py
 
+import argparse
 import datetime
+import json
 import locale
 import os
 import subprocess
@@ -839,9 +841,18 @@ def get_pretty_env_info():
     return pretty_str(get_env_info())
 
 
+def get_json_env_info():
+    return json.dumps(get_env_info()._asdict(), indent=2, sort_keys=True)
+
+
 def main():
-    print("Collecting environment information...")
-    output = get_pretty_env_info()
+    parser = argparse.ArgumentParser(description="Collect vLLM-MetaX environment information.")
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
+    args = parser.parse_args()
+
+    if not args.json:
+        print("Collecting environment information...")
+    output = get_json_env_info() if args.json else get_pretty_env_info()
     print(output)
 
     if (

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -546,7 +546,7 @@ def get_pip_packages(run_lambda, patterns=None):
         if pip_available:
             cmd = [sys.executable, "-mpip", "list", "--format=freeze"]
         elif os.environ.get("UV") is not None:
-            print("uv is set")
+            print("uv is set", file=sys.stderr)
             cmd = ["uv", "pip", "list", "--format=freeze"]
         else:
             raise RuntimeError(
@@ -590,7 +590,7 @@ def get_env_vars():
     try:
         from vllm.envs import environment_variables as vllm_envs
     except Exception as e:
-        print(e)
+        print(e, file=sys.stderr)
         vllm_envs = {}
 
     # 尝试导入插件环境变量

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -6,6 +6,7 @@
 # code borrowed from https://github.com/pytorch/pytorch/blob/main/torch/utils/collect_env.py
 
 import argparse
+import contextlib
 import datetime
 import json
 import locale
@@ -850,9 +851,12 @@ def main():
     parser.add_argument("--json", action="store_true", help="Print machine-readable JSON.")
     args = parser.parse_args()
 
-    if not args.json:
+    if args.json:
+        with contextlib.redirect_stdout(sys.stderr):
+            output = get_json_env_info()
+    else:
         print("Collecting environment information...")
-    output = get_json_env_info() if args.json else get_pretty_env_info()
+        output = get_pretty_env_info()
     print(output)
 
     if (


### PR DESCRIPTION
该 PR 为环境诊断结果增加结构化 JSON 输出，便于 CI、问题反馈和性能测试脚本稳定解析沐曦相关配置，而不是依赖人工阅读控制台文本。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/collect-env-json-output`，目标仓库：`MetaX-MACA/vLLM-metax`。