### PR TITLE
报告关键 MACA 环境变量

### DIFF
--- a/tests/test_collect_env_maca.py
+++ b/tests/test_collect_env_maca.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from vllm_metax.collect_env import get_env_vars
+
+
+class TestCollectEnvMacaVars(unittest.TestCase):
+
+    def test_collects_maca_runtime_variables(self):
+        env = {
+            "MACA_PATH": "/opt/maca",
+            "CUCC_PATH": "/opt/maca/tools/cu-bridge",
+            "MCCL_DEBUG": "INFO",
+            "MX_VISIBLE_DEVICES": "0",
+            "GITLINK_TOKEN": "must-not-leak",
+            "OPENAI_API_KEY": "must-not-leak-either",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            output = get_env_vars()
+
+        self.assertIn("MACA_PATH=/opt/maca", output)
+        self.assertIn("CUCC_PATH=/opt/maca/tools/cu-bridge", output)
+        self.assertIn("MCCL_DEBUG=INFO", output)
+        self.assertIn("MX_VISIBLE_DEVICES=0", output)
+        self.assertNotIn("GITLINK_TOKEN", output)
+        self.assertNotIn("OPENAI_API_KEY", output)
+        self.assertNotIn("must-not-leak", output)
+
+    def test_does_not_duplicate_known_prefixed_variables(self):
+        with patch.dict(
+            os.environ,
+            {"MACA_VLLM_ENABLE_MCTLASS_PYTHON_API": "1"},
+            clear=True,
+        ):
+            lines = get_env_vars().splitlines()
+
+        self.assertEqual(lines.count("MACA_VLLM_ENABLE_MCTLASS_PYTHON_API=1"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -601,7 +601,7 @@ def get_env_vars():
 
     env_vars = []
     reported = set()
-    secret_terms = ("secret", "token", "api_key", "apikey", "access", "password")
+    secret_terms = ("secret", "token", "api", "access", "password")
     report_prefix = (
         "TORCH",
         "NCCL",
@@ -627,7 +627,7 @@ def get_env_vars():
         env_vars.append("{}={}".format(name, value))
 
     for k, v in os.environ.items():
-        if any(term in k.lower() for term in secret_terms):
+        if any(term in k.lower() for term in secret_terms) and not k.endswith("_PYTHON_API"):
             continue
         if k in all_envs:
             add_env_var(k, v)

--- a/vllm_metax/collect_env.py
+++ b/vllm_metax/collect_env.py
@@ -599,28 +599,42 @@ def get_env_vars():
 
     all_envs = vllm_envs | plugin_envs
 
-    env_vars = ""
-    secret_terms = ("secret", "token", "api", "access", "password")
+    env_vars = []
+    reported = set()
+    secret_terms = ("secret", "token", "api_key", "apikey", "access", "password")
     report_prefix = (
         "TORCH",
         "NCCL",
+        "MCCL",
         "PYTORCH",
         "CUDA",
+        "CUCC",
         "CUBLAS",
         "CUDNN",
+        "MACA",
+        "METAX",
+        "MX",
+        "MXSML",
         "OMP_",
         "MKL_",
         "NVIDIA",
     )
+
+    def add_env_var(name, value):
+        if name in reported:
+            return
+        reported.add(name)
+        env_vars.append("{}={}".format(name, value))
+
     for k, v in os.environ.items():
         if any(term in k.lower() for term in secret_terms):
             continue
         if k in all_envs:
-            env_vars = env_vars + "{}={}".format(k, v) + "\n"
+            add_env_var(k, v)
         if k.startswith(report_prefix):
-            env_vars = env_vars + "{}={}".format(k, v) + "\n"
+            add_env_var(k, v)
 
-    return env_vars
+    return "\n".join(env_vars)
 
 
 def get_env_info():


### PR DESCRIPTION
该 PR 在环境信息中补充关键 MACA 环境变量，方便复现沐曦推理环境并快速发现变量缺失或配置漂移。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/report-maca-env-vars`，目标仓库：`MetaX-MACA/vLLM-metax`。