### PR TITLE
解析沐曦 CUDA 兼容编译器

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,26 @@ def is_url_available(url: str) -> bool:
     return status == 200
 
 
+def get_maca_cuda_compiler() -> str:
+    candidates = []
+    if CUDA_HOME:
+        candidates.append(Path(CUDA_HOME) / "bin" / "nvcc")
+    if os.getenv("CUCC_PATH"):
+        candidates.append(Path(os.environ["CUCC_PATH"]) / "bin" / "cucc")
+    if os.getenv("MACA_PATH"):
+        candidates.append(Path(os.environ["MACA_PATH"]) / "tools" / "cu-bridge" / "bin" / "cucc")
+
+    for compiler in candidates:
+        if compiler.is_file() and os.access(compiler, os.X_OK):
+            return str(compiler)
+
+    searched = ", ".join(str(path) for path in candidates) or "<none>"
+    raise RuntimeError(
+        "Cannot find MACA CUDA compiler. Set CUDA_HOME/CUDA_PATH or CUCC_PATH "
+        f"to a valid cu-bridge installation. Searched: {searched}"
+    )
+
+
 class CMakeExtension(Extension):
     def __init__(self, name: str, cmake_lists_dir: str = ".", **kwa) -> None:
         super().__init__(name, sources=[], py_limited_api=True, **kwa)
@@ -189,9 +209,9 @@ class cmake_build_ext(build_ext):
             # Default build tool to whatever cmake picks.
             build_tool = []
 
-        # Make sure we use the nvcc from CUDA_HOME
+        # MetaX SDK images may expose cu-bridge as cucc instead of nvcc.
         if _is_maca():
-            cmake_args += [f"-DCMAKE_CUDA_COMPILER={CUDA_HOME}/bin/nvcc"]
+            cmake_args += [f"-DCMAKE_CUDA_COMPILER={get_maca_cuda_compiler()}"]
             cmake_args += ["-DUSE_MACA=1"]
 
         if not _build_custom_ops():

--- a/setup.py
+++ b/setup.py
@@ -85,12 +85,12 @@ def is_url_available(url: str) -> bool:
 
 def get_maca_cuda_compiler() -> str:
     candidates = []
-    if CUDA_HOME:
-        candidates.append(Path(CUDA_HOME) / "bin" / "nvcc")
     if os.getenv("CUCC_PATH"):
         candidates.append(Path(os.environ["CUCC_PATH"]) / "bin" / "cucc")
     if os.getenv("MACA_PATH"):
         candidates.append(Path(os.environ["MACA_PATH"]) / "tools" / "cu-bridge" / "bin" / "cucc")
+    if CUDA_HOME:
+        candidates.append(Path(CUDA_HOME) / "bin" / "nvcc")
 
     for compiler in candidates:
         if compiler.is_file() and os.access(compiler, os.X_OK):


### PR DESCRIPTION
该 PR 增加对沐曦 CUDA 兼容编译器位置的解析逻辑，使需要编译扩展或检查工具链的场景能获得更准确的编译器路径。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/resolve-maca-cuda-compiler`，目标仓库：`MetaX-MACA/vLLM-metax`。