### PR TITLE
校验布尔环境变量取值

### DIFF
--- a/tests/test_env_bool_parser.py
+++ b/tests/test_env_bool_parser.py
@@ -1,0 +1,48 @@
+import ast
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_bool_parser():
+    source_path = Path(__file__).resolve().parents[1] / "vllm_metax" / "envs.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Import)
+            and any(alias.name == "os" for alias in node.names)
+        )
+        or (isinstance(node, ast.FunctionDef) and node.name == "_parse_bool_env")
+    ]
+    module = ast.Module(body=nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, str(source_path), "exec"), namespace)
+    return namespace["_parse_bool_env"]
+
+
+def test_bool_parser_accepts_zero_and_one():
+    parse_bool = _load_bool_parser()
+    with patch.dict(os.environ, {"FLAG": "1"}, clear=True):
+        assert parse_bool("FLAG", "0") is True
+    with patch.dict(os.environ, {"FLAG": "0"}, clear=True):
+        assert parse_bool("FLAG", "1") is False
+
+
+def test_bool_parser_reports_variable_name():
+    parse_bool = _load_bool_parser()
+    with patch.dict(os.environ, {"FLAG": "yes"}, clear=True):
+        try:
+            parse_bool("FLAG", "0")
+        except ValueError as err:
+            assert "FLAG" in str(err)
+            assert "0 or 1" in str(err)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+if __name__ == "__main__":
+    test_bool_parser_accepts_zero_and_one()
+    test_bool_parser_reports_variable_name()

--- a/tests/test_env_bool_parser.py
+++ b/tests/test_env_bool_parser.py
@@ -1,41 +1,24 @@
-import ast
 import os
 from pathlib import Path
+import sys
 from unittest.mock import patch
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-def _load_bool_parser():
-    source_path = Path(__file__).resolve().parents[1] / "vllm_metax" / "envs.py"
-    tree = ast.parse(source_path.read_text(encoding="utf-8"))
-    nodes = [
-        node
-        for node in tree.body
-        if (
-            isinstance(node, ast.Import)
-            and any(alias.name == "os" for alias in node.names)
-        )
-        or (isinstance(node, ast.FunctionDef) and node.name == "_parse_bool_env")
-    ]
-    module = ast.Module(body=nodes, type_ignores=[])
-    ast.fix_missing_locations(module)
-    namespace = {}
-    exec(compile(module, str(source_path), "exec"), namespace)
-    return namespace["_parse_bool_env"]
+from vllm_metax.envs import _parse_bool_env
 
 
 def test_bool_parser_accepts_zero_and_one():
-    parse_bool = _load_bool_parser()
     with patch.dict(os.environ, {"FLAG": "1"}, clear=True):
-        assert parse_bool("FLAG", "0") is True
+        assert _parse_bool_env("FLAG", "0") is True
     with patch.dict(os.environ, {"FLAG": "0"}, clear=True):
-        assert parse_bool("FLAG", "1") is False
+        assert _parse_bool_env("FLAG", "1") is False
 
 
 def test_bool_parser_reports_variable_name():
-    parse_bool = _load_bool_parser()
     with patch.dict(os.environ, {"FLAG": "yes"}, clear=True):
         try:
-            parse_bool("FLAG", "0")
+            _parse_bool_env("FLAG", "0")
         except ValueError as err:
             assert "FLAG" in str(err)
             assert "0 or 1" in str(err)

--- a/vllm_metax/envs.py
+++ b/vllm_metax/envs.py
@@ -22,6 +22,14 @@ if TYPE_CHECKING:
     VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER: bool = False
     VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK: bool = False
 
+
+def _parse_bool_env(name: str, default: str) -> bool:
+    value = os.getenv(name, default)
+    if value not in {"0", "1"}:
+        raise ValueError(f"{name} must be set to 0 or 1, got {value!r}")
+    return bool(int(value))
+
+
 environment_variables: dict[str, Callable[[], Any]] = {
     # ================== Installation Time Env Vars ==================
     # Target device of vLLM, supporting [cuda (by default),
@@ -39,7 +47,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Available options: "Debug", "Release", "RelWithDebInfo"
     "CMAKE_BUILD_TYPE": lambda: os.getenv("CMAKE_BUILD_TYPE"),
     # If set, vllm will print verbose logs during installation
-    "VERBOSE": lambda: bool(int(os.getenv("VERBOSE", "0"))),
+    "VERBOSE": lambda: _parse_bool_env("VERBOSE", "0"),
     # path to cudatoolkit home directory, under which should be bin, include,
     # and lib directories.
     "CUDA_HOME": lambda: os.environ.get("CUDA_HOME", None),
@@ -51,45 +59,41 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "LD_LIBRARY_PATH": lambda: os.environ.get("LD_LIBRARY_PATH", None),
     # if set, vllm-metax kernels would be imported from mcoplib and won't compile
     # during building
-    "USE_PRECOMPILED_KERNEL": lambda: bool(
-        int(os.environ.get("USE_PRECOMPILED_KERNEL", "1"))
-    ),
+    "USE_PRECOMPILED_KERNEL": lambda: _parse_bool_env("USE_PRECOMPILED_KERNEL", "1"),
     # ================== Runtime Env Vars ==================
     # if set, enable mctlass python api, only support scaled_mm and moe_w8a8 int8
-    "MACA_VLLM_ENABLE_MCTLASS_PYTHON_API": lambda: bool(
-        int(os.getenv("MACA_VLLM_ENABLE_MCTLASS_PYTHON_API", "1"))
+    "MACA_VLLM_ENABLE_MCTLASS_PYTHON_API": lambda: _parse_bool_env(
+        "MACA_VLLM_ENABLE_MCTLASS_PYTHON_API", "1"
     ),
     # if set, enable bf16 cutlass moe on stage2
     # or w8a8 cutlass moe on both stage1 and stage2
-    "MACA_VLLM_ENABLE_MCTLASS_FUSED_MOE": lambda: bool(
-        int(os.getenv("MACA_VLLM_ENABLE_MCTLASS_FUSED_MOE", "0"))
+    "MACA_VLLM_ENABLE_MCTLASS_FUSED_MOE": lambda: _parse_bool_env(
+        "MACA_VLLM_ENABLE_MCTLASS_FUSED_MOE", "0"
     ),
     # if set, enable combine allreduce all2all
-    "VLLM_METAX_OPTIMIZED_DP_ALL2ALL": lambda: bool(
-        int(os.environ.get("VLLM_METAX_OPTIMIZED_DP_ALL2ALL", "0"))
+    "VLLM_METAX_OPTIMIZED_DP_ALL2ALL": lambda: _parse_bool_env(
+        "VLLM_METAX_OPTIMIZED_DP_ALL2ALL", "0"
     ),
     # if set, enable FA split forward into
     # prefill and decode for better latency
     # and memory usage during decoding
-    "VLLM_METAX_ENABLE_FA_SPLIT_FORWARD": lambda: bool(
-        int(os.environ.get("VLLM_METAX_ENABLE_FA_SPLIT_FORWARD", "1"))
+    "VLLM_METAX_ENABLE_FA_SPLIT_FORWARD": lambda: _parse_bool_env(
+        "VLLM_METAX_ENABLE_FA_SPLIT_FORWARD", "1"
     ),
     "VLLM_FUSED_MOE_CHUNK_SIZE": lambda: int(
         os.getenv("VLLM_FUSED_MOE_CHUNK_SIZE", str(16 * 1024))
     ),
     # if set, use fp8 deep gemm kernel for DSA
-    "VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER": lambda: bool(
-        int(os.environ.get("VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER", "0"))
+    "VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER": lambda: _parse_bool_env(
+        "VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER", "0"
     ),
     # if set, enable sglang fused grouped topk ops on deepseek and kimi model
-    "VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK": lambda: bool(
-        int(os.getenv("VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK", "0"))
+    "VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK": lambda: _parse_bool_env(
+        "VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK", "0"
     ),
     # =================== Debug Env Vars ==================
     # if set, use vllm's fused_moe implementation instead of maca's one for debugging and comparison
-    "USE_VLLM_TRITON_EXPERT": lambda: bool(
-        int(os.getenv("USE_VLLM_TRITON_EXPERT", "0"))
-    ),
+    "USE_VLLM_TRITON_EXPERT": lambda: _parse_bool_env("USE_VLLM_TRITON_EXPERT", "0"),
 }
 
 


### PR DESCRIPTION
该 PR 对布尔型环境变量增加合法值校验，避免拼写错误静默落入默认行为，提升推理部署时的可观测性。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/validate-bool-env-values`，目标仓库：`MetaX-MACA/vLLM-metax`。