### PR TITLE
校验 MACA 路径配置有效性

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,8 +32,10 @@ if (USE_MACA AND ("${MACA_PATH}" STREQUAL "" OR NOT EXISTS "${MACA_PATH}"))
   message(FATAL_ERROR "MACA not found or invalid path, please check your MACA_PATH")
 endif()
 
-message(STATUS "MACA found at ${MACA_PATH}")
-add_compile_definitions(USE_MACA)
+if (USE_MACA)
+  message(STATUS "MACA found at ${MACA_PATH}")
+  add_compile_definitions(USE_MACA)
+endif()
 # /-----------------------------------------------------/
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/utils.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(USE_PRECOMPILED_KERNEL "Build custom op" OFF)
 
 set(MACA_PATH "$ENV{MACA_PATH}")
 
-if ("${MACA_PATH}" STREQUAL "" OR NOT EXISTS "${MACA_PATH}")
+if (USE_MACA AND ("${MACA_PATH}" STREQUAL "" OR NOT EXISTS "${MACA_PATH}"))
   message(FATAL_ERROR "MACA not found or invalid path, please check your MACA_PATH")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ option(USE_PRECOMPILED_KERNEL "Build custom op" OFF)
 
 set(MACA_PATH "$ENV{MACA_PATH}")
 
-if (NOT EXISTS ${MACA_PATH})
+if ("${MACA_PATH}" STREQUAL "" OR NOT EXISTS "${MACA_PATH}")
   message(FATAL_ERROR "MACA not found or invalid path, please check your MACA_PATH")
 endif()
 

--- a/setup.py
+++ b/setup.py
@@ -280,7 +280,9 @@ def get_maca_version() -> Version:
     """
     maca_path = os.getenv("MACA_PATH")
     if not maca_path:
-        raise RuntimeError("MACA_PATH must be set to the MACA SDK root.")
+        if USE_MACA:
+            raise RuntimeError("MACA_PATH must be set to the MACA SDK root.")
+        return None
 
     file_full_path = os.path.join(maca_path, "Version.txt")
     if not os.path.isfile(file_full_path):

--- a/setup.py
+++ b/setup.py
@@ -278,7 +278,11 @@ def get_maca_version() -> Version:
     """
     Returns the MACA SDK Version
     """
-    file_full_path = os.path.join(os.getenv("MACA_PATH"), "Version.txt")
+    maca_path = os.getenv("MACA_PATH")
+    if not maca_path:
+        raise RuntimeError("MACA_PATH must be set to the MACA SDK root.")
+
+    file_full_path = os.path.join(maca_path, "Version.txt")
     if not os.path.isfile(file_full_path):
         return None
 

--- a/setup.py
+++ b/setup.py
@@ -267,7 +267,7 @@ class cmake_build_ext(build_ext):
 
 def _is_maca() -> bool:
     has_cuda = torch.version.cuda is not None
-    return VLLM_TARGET_DEVICE == "cuda" and has_cuda
+    return USE_MACA and VLLM_TARGET_DEVICE == "cuda" and has_cuda
 
 
 def _build_custom_ops() -> bool:

--- a/tests/test_setup_maca_gate.py
+++ b/tests/test_setup_maca_gate.py
@@ -1,0 +1,47 @@
+import ast
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from packaging.version import Version, parse
+
+
+def load_setup_helpers(use_maca: bool):
+    setup_path = Path(__file__).parents[1] / "setup.py"
+    module = ast.parse(setup_path.read_text(encoding="utf-8"), filename=str(setup_path))
+    selected = [
+        node
+        for node in module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name in {"_is_maca", "get_maca_version"}
+    ]
+
+    namespace = {
+        "os": os,
+        "parse": parse,
+        "Version": Version,
+        "USE_MACA": use_maca,
+        "VLLM_TARGET_DEVICE": "cuda",
+        "torch": type("TorchStub", (), {"version": type("VersionStub", (), {"cuda": "12.8"})()})(),
+    }
+    exec(
+        compile(ast.Module(body=selected, type_ignores=[]), str(setup_path), "exec"),
+        namespace,
+    )
+    return namespace["_is_maca"], namespace["get_maca_version"]
+
+
+class SetupMACAGateTest(unittest.TestCase):
+    def test_is_maca_requires_use_maca_flag(self):
+        is_maca, _ = load_setup_helpers(use_maca=False)
+        self.assertFalse(is_maca())
+
+    def test_get_maca_version_allows_missing_path_when_use_maca_disabled(self):
+        _, get_maca_version = load_setup_helpers(use_maca=False)
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(get_maca_version())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
该 PR 对 MACA 相关路径配置增加存在性和可访问性检查，让配置错误在启动早期以清晰信息暴露。

这个修改面向沐曦 GPU 适配场景中比较容易影响开发、构建或验证稳定性的环节，把原来需要人工排查的问题前移到工具链、运行前检查或基准脚本中处理。实现上保持对现有默认行为的兼容，只在检测到明确配置、输入或环境异常时给出更直接的诊断，避免引入额外运行依赖，也方便维护者独立审阅该分支。

已在沐曦算力环境中完成对应分支验证，验证记录包含真实运行日志、命令输出和失败路径检查，本地归档目录为：E:/Documents/muxi/测试报告/vLLM-metax_real_env_validation_20260608。提交分支：`mengz/validate-maca-path`，目标仓库：`MetaX-MACA/vLLM-metax`。