### PR TITLE
[BugFix] call ops.top_k_per_row_prefill in int8 indexer prefill

### DIFF
--- a/vllm_metax/customized/layers/sparse_attn_indexer/int8.py
+++ b/vllm_metax/customized/layers/sparse_attn_indexer/int8.py
@@ -180,7 +180,7 @@ def sparse_attn_indexer_int8(
                 chunk.token_start : chunk.token_end, :topk_tokens
             ]
 
-            torch.ops.top_k_per_row_prefill(
+            ops.top_k_per_row_prefill(
                 logits,
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,


### PR DESCRIPTION
torch.ops.top_k_per_row_prefill resolves to an op namespace, which is not callable, so the int8 sparse-attn-indexer prefill path raised TypeError. Match the bf16/fp8 paths and the decode path below, all of which use ops.top_k_per_row_prefill.

<!-- markdownlint-disable -->
## Purpose

Fix a crash in the int8 sparse-attn-indexer prefill path.

`int8.py:183` calls `torch.ops.top_k_per_row_prefill(...)`, which resolves to an
op **namespace** (not callable), so any model with FP8/int8 sparse attn indexer
(e.g. DeepSeek-V3.2) raises `TypeError: '_OpNamespace' object is not callable`
when the prefill path runs.

One-line fix: use `ops.top_k_per_row_prefill(...)` from `vllm._custom_ops`
(already imported at line 8), matching the bf16 path (`bf16.py:181`), the fp8
path (`fp8.py:216`) and the decode path in the same file (`int8.py:254`).

## Test Plan

Minimal repro of the broken call form (no GPU needed):

```bash
python -c "import torch; torch.ops.top_k_per_row_prefill(1)"
```

```bash
grep -rE "torch\.ops\.[a-z_0-9]+\(" vllm_metax/ | grep -v "torch.ops._"
```
to confirm this is the only raw-namespace call site of this class.

## Test Result

- Before: `TypeError: '_OpNamespace' object is not callable`
- After fix: int8 prefill resolves the same `_C.top_k_per_row_prefill` op as the bf16/fp8 paths.
- grep: no remaining raw-namespace call sites.

## (Optional) Documentation Update

None.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>