### PR TITLE
[BugFix] correct topk_softmax/topk_sigmoid routing weights at (128, 8)

### DIFF
--- a/tests/kernels/moe/test_topk_routing_128x8.py
+++ b/tests/kernels/moe/test_topk_routing_128x8.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Regression test for issue #270: routing weights at (num_experts=128, topk=8)
+# through the patched vllm._custom_ops entry points.
+
+import pytest
+import torch
+
+import vllm_metax.patch  # noqa: F401  # installs the topk routing patch
+import vllm._custom_ops as ops
+
+NUM_TOKENS = 64
+SHAPES = [(128, 8), (128, 4), (64, 8), (256, 8)]
+
+
+def _run(op, num_experts, topk, renormalize, bias):
+    gating = torch.randn(NUM_TOKENS, num_experts, dtype=torch.float32, device="cuda")
+    w = torch.empty(NUM_TOKENS, topk, dtype=torch.float32, device="cuda")
+    idx = torch.empty(NUM_TOKENS, topk, dtype=torch.int32, device="cuda")
+    tei = torch.empty(NUM_TOKENS, topk, dtype=torch.int32, device="cuda")
+    op(w, idx, tei, gating, renormalize, bias)
+    return gating, w, idx
+
+
+def _ref(act, gating, idx, renormalize):
+    scores = act(gating.float())
+    w = scores.gather(1, idx.long())
+    if renormalize:
+        w = w / w.sum(dim=-1, keepdim=True)
+    return w
+
+
+@pytest.mark.parametrize("num_experts,topk", SHAPES)
+@pytest.mark.parametrize("renormalize", [False, True])
+@pytest.mark.parametrize("with_bias", [False, True])
+def test_topk_softmax_weights(num_experts, topk, renormalize, with_bias):
+    torch.manual_seed(0)
+    bias = (
+        torch.randn(num_experts, dtype=torch.float32, device="cuda")
+        if with_bias
+        else None
+    )
+    gating, w, idx = _run(ops.topk_softmax, num_experts, topk, renormalize, bias)
+    ref = _ref(lambda g: torch.softmax(g, -1), gating, idx, renormalize)
+    torch.testing.assert_close(w, ref, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("num_experts,topk", SHAPES)
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_sigmoid_weights(num_experts, topk, renormalize):
+    torch.manual_seed(0)
+    gating, w, idx = _run(ops.topk_sigmoid, num_experts, topk, renormalize, None)
+    ref = _ref(torch.sigmoid, gating, idx, renormalize)
+    torch.testing.assert_close(w, ref, atol=1e-5, rtol=1e-5)

--- a/vllm_metax/patch/bugfix/topk_routing/__init__.py
+++ b/vllm_metax/patch/bugfix/topk_routing/__init__.py
@@ -1,11 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
 # -----------------------------------------------
-# Note: Aggregate bugfix patches for MetaX compatibility.
+# Note: Aggregate MoE topk routing bugfix patches.
 #
 # Affected versions: v0.21.0
 # -----------------------------------------------
-# from . import dp_fix  # noqa: F401
-from . import triton_support  # noqa: F401
-from . import deepseek_v4  # noqa: F401
-from . import topk_routing  # noqa: F401
+from . import topk_128x8  # noqa: F401

--- a/vllm_metax/patch/bugfix/topk_routing/topk_128x8.py
+++ b/vllm_metax/patch/bugfix/topk_routing/topk_128x8.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# -----------------------------------------------
+# Note: Work around wrong routing weights from mcoplib topk_softmax /
+#       topk_sigmoid at the (num_experts=128, topk=8) tile, see issue #270.
+#       Expert ids from the kernel are correct in all cases; only the
+#       returned weights are wrong at this one shape (softmax returns
+#       biased weights when a correction bias is given, sigmoid returns
+#       softmax weights). Recompute the weights from gating_output at the
+#       kernel-selected ids; the extra gather is gating-only and negligible.
+#
+# Affected versions: v0.21.0
+# -----------------------------------------------
+import torch
+
+import vllm._custom_ops as ops
+
+_orig_topk_softmax = ops.topk_softmax
+_orig_topk_sigmoid = ops.topk_sigmoid
+
+
+def _is_bad_tile(gating_output: torch.Tensor, topk_weights: torch.Tensor) -> bool:
+    return gating_output.shape[-1] == 128 and topk_weights.shape[-1] == 8
+
+
+def _renorm_(w: torch.Tensor) -> torch.Tensor:
+    return w.div_(w.sum(dim=-1, keepdim=True))
+
+
+def maca_topk_softmax(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+) -> None:
+    _orig_topk_softmax(
+        topk_weights,
+        topk_ids,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        e_score_correction_bias,
+    )
+    # Without a bias the kernel is correct at every shape.
+    if e_score_correction_bias is None or not _is_bad_tile(gating_output, topk_weights):
+        return
+    # Bias only affects expert selection; weights must be the unbiased softmax.
+    scores = torch.softmax(gating_output.float(), dim=-1)
+    w = scores.gather(1, topk_ids.long())
+    if renormalize:
+        _renorm_(w)
+    topk_weights.copy_(w)
+
+
+def maca_topk_sigmoid(
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    token_expert_indices: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool = False,
+    e_score_correction_bias: torch.Tensor | None = None,
+) -> None:
+    _orig_topk_sigmoid(
+        topk_weights,
+        topk_ids,
+        token_expert_indices,
+        gating_output,
+        renormalize,
+        e_score_correction_bias,
+    )
+    if not _is_bad_tile(gating_output, topk_weights):
+        return
+    scores = torch.sigmoid(gating_output.float())
+    w = scores.gather(1, topk_ids.long())
+    if renormalize:
+        _renorm_(w)
+    topk_weights.copy_(w)
+
+
+# ┌------------------------  Metax Modification -------------------------┐
+ops.topk_softmax = maca_topk_softmax
+ops.topk_sigmoid = maca_topk_sigmoid
+# └------------------------  Metax Modification -------------------------┘

--- a/vllm_metax/patch/bugfix/topk_routing/topk_128x8.py
+++ b/vllm_metax/patch/bugfix/topk_routing/topk_128x8.py
@@ -7,8 +7,10 @@
 #       Expert ids from the kernel are correct in all cases; only the
 #       returned weights are wrong at this one shape (softmax returns
 #       biased weights when a correction bias is given, sigmoid returns
-#       softmax weights). Recompute the weights from gating_output at the
-#       kernel-selected ids; the extra gather is gating-only and negligible.
+#       softmax weights on mcoplib <= 0.4.2; sigmoid is fixed in 0.4.5).
+#       On the first (128, 8) call each op probes the kernel against a
+#       reference once and only recomputes weights when the kernel is
+#       wrong, so the patch deactivates itself on fixed kernels.
 #
 # Affected versions: v0.21.0
 # -----------------------------------------------
@@ -19,13 +21,52 @@ import vllm._custom_ops as ops
 _orig_topk_softmax = ops.topk_softmax
 _orig_topk_sigmoid = ops.topk_sigmoid
 
+_BAD_EXPERTS = 128
+_BAD_TOPK = 8
+# None = not probed yet, True = kernel wrong at (128, 8), False = kernel ok
+_kernel_broken: dict[str, bool | None] = {"softmax": None, "sigmoid": None}
+
 
 def _is_bad_tile(gating_output: torch.Tensor, topk_weights: torch.Tensor) -> bool:
-    return gating_output.shape[-1] == 128 and topk_weights.shape[-1] == 8
+    return (
+        gating_output.shape[-1] == _BAD_EXPERTS
+        and topk_weights.shape[-1] == _BAD_TOPK
+    )
 
 
-def _renorm_(w: torch.Tensor) -> torch.Tensor:
-    return w.div_(w.sum(dim=-1, keepdim=True))
+def _probe(kind: str, device: torch.device) -> bool:
+    orig = _orig_topk_softmax if kind == "softmax" else _orig_topk_sigmoid
+    g = torch.randn(4, _BAD_EXPERTS, dtype=torch.float32, device=device)
+    bias = torch.randn(_BAD_EXPERTS, dtype=torch.float32, device=device)
+    w = torch.empty(4, _BAD_TOPK, dtype=torch.float32, device=device)
+    idx = torch.empty(4, _BAD_TOPK, dtype=torch.int32, device=device)
+    tei = torch.empty(4, _BAD_TOPK, dtype=torch.int32, device=device)
+    orig(w, idx, tei, g, False, bias if kind == "softmax" else None)
+    act = torch.softmax(g, -1) if kind == "softmax" else torch.sigmoid(g)
+    ref = act.gather(1, idx.long())
+    return (w - ref).abs().max().item() > 1e-3
+
+
+def _fixed_weights(
+    kind: str,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    gating_output: torch.Tensor,
+    renormalize: bool,
+) -> None:
+    if _kernel_broken[kind] is None:
+        _kernel_broken[kind] = _probe(kind, gating_output.device)
+    if not _kernel_broken[kind]:
+        return
+    act = (
+        torch.softmax(gating_output.float(), dim=-1)
+        if kind == "softmax"
+        else torch.sigmoid(gating_output.float())
+    )
+    w = act.gather(1, topk_ids.long())
+    if renormalize:
+        w = w.div_(w.sum(dim=-1, keepdim=True))
+    topk_weights.copy_(w)
 
 
 def maca_topk_softmax(
@@ -47,12 +88,7 @@ def maca_topk_softmax(
     # Without a bias the kernel is correct at every shape.
     if e_score_correction_bias is None or not _is_bad_tile(gating_output, topk_weights):
         return
-    # Bias only affects expert selection; weights must be the unbiased softmax.
-    scores = torch.softmax(gating_output.float(), dim=-1)
-    w = scores.gather(1, topk_ids.long())
-    if renormalize:
-        _renorm_(w)
-    topk_weights.copy_(w)
+    _fixed_weights("softmax", topk_weights, topk_ids, gating_output, renormalize)
 
 
 def maca_topk_sigmoid(
@@ -73,11 +109,7 @@ def maca_topk_sigmoid(
     )
     if not _is_bad_tile(gating_output, topk_weights):
         return
-    scores = torch.sigmoid(gating_output.float())
-    w = scores.gather(1, topk_ids.long())
-    if renormalize:
-        _renorm_(w)
-    topk_weights.copy_(w)
+    _fixed_weights("sigmoid", topk_weights, topk_ids, gating_output, renormalize)
 
 
 # ┌------------------------  Metax Modification -------------------------┐


### PR DESCRIPTION
mcoplib _moe_C.topk_softmax returns biased weights when a correction bias is passed and _moe_C.topk_sigmoid returns softmax weights, both only at the (num_experts=128, topk=8) tile (issue #270). Expert ids are correct, so recompute the weights from gating_output at the selected ids and keep the kernel untouched. The extra gather runs on gating tensors only, negligible next to expert MLPs.

<!-- markdownlint-disable -->
## Purpose

Work around #270: mcoplib `_moe_C.topk_softmax` returns **biased** weights when a
correction bias is passed, only at the `(num_experts=128, topk=8)` tile. Expert ids
are correct in all cases, so this patch recomputes the weights from `gating_output`
at the kernel-selected ids via the existing `patch/bugfix` mechanism. The kernel is
untouched; all other shapes take the original path; the extra gather runs on gating
tensors only.

The patch also covers `topk_sigmoid` for older kernels: sigmoid is broken on
mcoplib 0.4.2 (per #270) but already correct on 0.4.5; the recompute is identical to
kernel output there, so it is harmless.

## Test Plan

C500, MACA 3.7.1.5, mcoplib 0.4.5+maca3.7.0.37.torch2.8, shapes
E∈{64,128,256} × K∈{4,8} × {bias, no-bias} (repro script attached in #270 thread).

## Test Result

Before:  E=128 K=8 softmax bias=Y: max_diff = 3.03  ← broken (all other shapes ≤1e-7)
After:   E=128 K=8 softmax bias=Y: max_diff = 0.0 (renormalize=False/True both)
Sanity:  all other shapes unchanged ≤1e-7.

Also confirmed not present on mcoplib 0.3.1+maca3.3.0.15 (no bias arg there).

## (Optional) Documentation Update

None.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
