### PR TITLE
[FA] reuse max_seq_len for prefill_max_seq_len

### DIFF
--- a/vllm_metax/v1/attention/backends/flash_attn.py
+++ b/vllm_metax/v1/attention/backends/flash_attn.py
@@ -640,10 +640,10 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
                 - common_attn_metadata.query_start_loc[num_decodes]
             )
             prefill_seq_lens = common_attn_metadata.seq_lens[num_decodes:num_reqs]
-            prefill_seq_lens_cpu = common_attn_metadata.seq_lens_cpu[
-                num_decodes:num_reqs
-            ]
-            prefill_max_seq_len = int(prefill_seq_lens_cpu.max().item())
+            # max_seq_len already bounds the prefill rows and is all that
+            # max_seqlen_k needs, so reuse it instead of slicing the deprecated
+            # seq_lens_cpu just to take its max.
+            prefill_max_seq_len = max_seq_len
             prefill_block_table_tensor = common_attn_metadata.block_table_tensor[
                 num_decodes:num_reqs
             ]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

Follow-up to #260. When building FlashAttention metadata for prefill, the
builder slices `common_attn_metadata.seq_lens_cpu[num_decodes:num_reqs]` and
takes its `.max()` to fill `prefill_max_seq_len`:

```python
prefill_seq_lens_cpu = common_attn_metadata.seq_lens_cpu[num_decodes:num_reqs]
prefill_max_seq_len = int(prefill_seq_lens_cpu.max().item())
```

`prefill_max_seq_len` is only consumed as the `max_seqlen_k` argument of
`flash_attn_varlen_func` on the prefill-decode split path, i.e. a launch-time
upper bound. `max_seq_len` is already computed at the top of `build()` as the
max over *all* rows, so it is a valid (and tight, since decode rows are short)
bound for the prefill rows too. Reusing it lets us drop the per-build
`seq_lens_cpu` slice entirely:

```python
prefill_max_seq_len = max_seq_len
```

This also removes the last `seq_lens_cpu` access in this builder. Upstream has
deprecated that property in favour of using the device `seq_lens` directly, so
dropping it keeps the backend aligned with upstream.

## Test Plan

The change is intended to be behaviour-preserving, so the goal is to show the
value handed to the kernel is unchanged in effect:

- `max_seq_len = max(seq_lens)` over all requests ≥ `max(seq_lens[prefill])`.
- `prefill_max_seq_len` flows only into `max_seqlen_k`, which FlashAttention
  treats as an upper bound on the K sequence length.

## Test Result

`max_seqlen_k` is `>=` the previous value and remains an upper bound, so kernel
outputs are unchanged. The removed line was the only consumer of
`prefill_seq_lens_cpu`; `prefill_seq_lens` (device) is still used to build
`cu_prefix_kv_lens`. `python -m py_compile` passes.

I don't have a MACA runtime matching current `master` to run the full backend
suite end to end, so this is reviewed as a behaviour-preserving simplification
rather than a benchmarked perf change; happy to add numbers if a maintainer can
point me at the right harness.

## (Optional) Documentation Update

None.
