### PR TITLE
docs: align vllm source branch with 0.23

### DIFF
--- a/docs/getting_started/installation/maca.md
+++ b/docs/getting_started/installation/maca.md
@@ -76,10 +76,11 @@ Build the plugin:
 
     This would install a *cuda-build* vllm which carried a lot of cuda-related dependencies and kernel files together with internal vllm_flash_attn and triton_kernels, which may wrongly cause runtime errors on some checking. (E.g. Some pre-conditions that should **only** be detected on `cuda` may also passed to `maca` backend by mistake in this kind of vllm.)
 
-Clone vllm project:
+Clone the vLLM branch that matches the current vllm-metax version. The current
+master branch is aligned with vLLM v0.23.0:
 
-```bash 
-git clone  --depth 1 --branch releases/v0.22.0 https://github.com/vllm-project/vllm 
+```bash
+git clone --depth 1 --branch releases/v0.23.0 https://github.com/vllm-project/vllm
 cd vllm
 ```
 


### PR DESCRIPTION
## Summary

- fix the vLLM source-build branch documented for the v0.23 line
- change the example from `releases/v0.22.0` to `releases/v0.23.0`
- make the wording branch-specific instead of referring to the current master

## Why

On `v0.23.0-dev`, `setup.py` reports v0.23.0, while the installation guide still instructs users to clone the vLLM `releases/v0.22.0` branch.

The current `master` branch has already moved to v0.24.0 and its documentation now points to `releases/v0.24.0`. Therefore this fix is intended only for `v0.23.0-dev`, subject to maintainer confirmation.

## Validation

- `git diff --check`: passed
- verified that `v0.23.0-dev/setup.py` reports `0.23.0`
- verified that the upstream vLLM `releases/v0.23.0` branch exists
