### PR TITLE
Fix MetaX vLLM 0.23 MTP compatibility

### DIFF
--- a/tests/patch/test_moe_wna16_compat.py
+++ b/tests/patch/test_moe_wna16_compat.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+
+import vllm_metax.quant_config.moe_wna16 as moe_wna16
+
+
+def test_moe_wna16_apply_tolerates_missing_disable_inplace(monkeypatch):
+    captured = {}
+
+    def fake_fused_experts(*args, **kwargs):
+        captured.update(kwargs)
+        return torch.empty(1)
+
+    monkeypatch.setattr(
+        moe_wna16, "get_fused_experts_fn", lambda: fake_fused_experts
+    )
+
+    method = object.__new__(moe_wna16.MoeWNA16Method)
+    method.moe = SimpleNamespace()
+    method.moe_quant_config = object()
+
+    layer = SimpleNamespace(
+        activation=MoEActivation.SILU,
+        w13_qweight=torch.empty(1),
+        w2_qweight=torch.empty(1),
+        apply_router_weight_on_input=False,
+        global_num_experts=1,
+        expert_map=None,
+    )
+
+    result = method.apply(
+        layer,
+        torch.empty(1),
+        torch.empty(1),
+        torch.empty(1, dtype=torch.int64),
+        None,
+        None,
+    )
+
+    assert result.shape == (1,)
+    assert captured["inplace"] is True

--- a/tests/patch/test_triton_custom_op_schemas.py
+++ b/tests/patch/test_triton_custom_op_schemas.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+def test_custom_op_schemas_allow_act_quant_fusion_import():
+    import torch
+
+    import vllm_metax.compat  # noqa: F401
+
+    assert hasattr(torch.ops._C.scaled_fp4_quant, "out")
+    assert hasattr(torch.ops._C, "silu_and_mul_per_block_quant")
+    if hasattr(torch, "accelerator"):
+        assert hasattr(torch.accelerator, "empty_cache")
+
+    import vllm.compilation.passes.fusion.act_quant_fusion as act_quant_fusion
+
+    assert act_quant_fusion.SILU_MUL_OP is not None

--- a/tests/patch/test_triton_custom_op_schemas.py
+++ b/tests/patch/test_triton_custom_op_schemas.py
@@ -16,3 +16,16 @@ def test_custom_op_schemas_allow_act_quant_fusion_import():
     import vllm.compilation.passes.fusion.act_quant_fusion as act_quant_fusion
 
     assert act_quant_fusion.SILU_MUL_OP is not None
+
+
+def test_compat_import_tolerates_missing_torch_cuda(monkeypatch):
+    import importlib
+    import torch
+
+    import vllm_metax.compat as compat
+
+    with monkeypatch.context() as context:
+        context.delattr(torch, "cuda", raising=False)
+        importlib.reload(compat)
+
+    importlib.reload(compat)

--- a/vllm_metax/__init__.py
+++ b/vllm_metax/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
 
+from . import compat as _compat  # noqa: F401
 from .version import __version__, __version_tuple__  # noqa: F401
 
 

--- a/vllm_metax/compat.py
+++ b/vllm_metax/compat.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Early compatibility hooks for vLLM and MetaX runtime mismatches."""
+
+import torch
+from torch.library import Library
+
+_FRAGMENT_LIBS: list[Library] = []
+
+
+def _has_op_overload(name: str, overload_name: str | None = None) -> bool:
+    if not hasattr(torch.ops, "_C") or not hasattr(torch.ops._C, name):
+        return False
+    if overload_name is None:
+        return True
+    return hasattr(getattr(torch.ops._C, name), overload_name)
+
+
+def _define_fragment(schema: str) -> None:
+    try:
+        lib = Library("_C", "FRAGMENT")
+        lib.define(schema)
+        _FRAGMENT_LIBS.append(lib)
+    except Exception:
+        # Another package or prior import may have registered it already.
+        pass
+
+
+if not _has_op_overload("scaled_fp4_quant", "out"):
+    _define_fragment(
+        "scaled_fp4_quant.out("
+        "Tensor input, Tensor input_scale, bool is_sf_swizzled_layout, "
+        "*, Tensor! output, Tensor! output_scale) -> ()"
+    )
+
+if not _has_op_overload("silu_and_mul_per_block_quant"):
+    _define_fragment(
+        "silu_and_mul_per_block_quant("
+        "Tensor! output, Tensor input, Tensor! scales, int group_size, "
+        "Tensor? scale_ub, bool is_scale_transposed) -> ()"
+    )
+
+if hasattr(torch, "accelerator"):
+    for _name in (
+        "current_device",
+        "device_count",
+        "empty_cache",
+        "is_available",
+        "max_memory_allocated",
+        "mem_get_info",
+        "memory_allocated",
+        "memory_reserved",
+        "memory_stats",
+        "reset_peak_memory_stats",
+        "set_device",
+        "synchronize",
+    ):
+        if not hasattr(torch.accelerator, _name) and hasattr(torch.cuda, _name):
+            setattr(torch.accelerator, _name, getattr(torch.cuda, _name))
+    if (
+        not hasattr(torch.accelerator, "current_device_index")
+        and hasattr(torch.cuda, "current_device")
+    ):
+        torch.accelerator.current_device_index = torch.cuda.current_device

--- a/vllm_metax/compat.py
+++ b/vllm_metax/compat.py
@@ -42,24 +42,26 @@ if not _has_op_overload("silu_and_mul_per_block_quant"):
     )
 
 if hasattr(torch, "accelerator"):
-    for _name in (
-        "current_device",
-        "device_count",
-        "empty_cache",
-        "is_available",
-        "max_memory_allocated",
-        "mem_get_info",
-        "memory_allocated",
-        "memory_reserved",
-        "memory_stats",
-        "reset_peak_memory_stats",
-        "set_device",
-        "synchronize",
-    ):
-        if not hasattr(torch.accelerator, _name) and hasattr(torch.cuda, _name):
-            setattr(torch.accelerator, _name, getattr(torch.cuda, _name))
-    if (
-        not hasattr(torch.accelerator, "current_device_index")
-        and hasattr(torch.cuda, "current_device")
-    ):
-        torch.accelerator.current_device_index = torch.cuda.current_device
+    cuda_module = getattr(torch, "cuda", None)
+    if cuda_module is not None:
+        for _name in (
+            "current_device",
+            "device_count",
+            "empty_cache",
+            "is_available",
+            "max_memory_allocated",
+            "mem_get_info",
+            "memory_allocated",
+            "memory_reserved",
+            "memory_stats",
+            "reset_peak_memory_stats",
+            "set_device",
+            "synchronize",
+        ):
+            if not hasattr(torch.accelerator, _name) and hasattr(cuda_module, _name):
+                setattr(torch.accelerator, _name, getattr(cuda_module, _name))
+        if (
+            not hasattr(torch.accelerator, "current_device_index")
+            and hasattr(cuda_module, "current_device")
+        ):
+            torch.accelerator.current_device_index = cuda_module.current_device

--- a/vllm_metax/patch/bugfix/triton_support/__init__.py
+++ b/vllm_metax/patch/bugfix/triton_support/__init__.py
@@ -5,6 +5,7 @@
 #
 # Affected versions: v0.21.0
 # -----------------------------------------------
+from . import custom_op_schemas
 from . import kda
 from . import lora
 from . import chunk_delta_h

--- a/vllm_metax/patch/bugfix/triton_support/custom_op_schemas.py
+++ b/vllm_metax/patch/bugfix/triton_support/custom_op_schemas.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+# 2026 - Modified by MetaX Integrated Circuits (Shanghai) Co., Ltd. All Rights Reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Compatibility wrapper for legacy triton_support import paths."""
+
+from vllm_metax.compat import *  # noqa: F401,F403

--- a/vllm_metax/quant_config/moe_wna16.py
+++ b/vllm_metax/quant_config/moe_wna16.py
@@ -79,6 +79,7 @@ class MoeWNA16Method(vllm_MoeWNA16Method):
         )
 
         fused_experts = get_fused_experts_fn()
+        disable_inplace = getattr(self.moe, "disable_inplace", False)
 
         return fused_experts(
             x,
@@ -86,7 +87,7 @@ class MoeWNA16Method(vllm_MoeWNA16Method):
             layer.w2_qweight,
             topk_weights=topk_weights,
             topk_ids=topk_ids,
-            inplace=not self.moe.disable_inplace,
+            inplace=not disable_inplace,
             apply_router_weight_on_input=layer.apply_router_weight_on_input,
             global_num_experts=layer.global_num_experts,
             expert_map=layer.expert_map,


### PR DESCRIPTION
## Summary

Fix MetaX plugin startup for vLLM 0.23 Qwen3.5/Qwen3 MTP speculative decoding by installing early compatibility hooks before plugin-specific patches and vLLM compilation/fusion modules are imported.

## Root cause

The vLLM 0.23 MTP path imports quantization/fusion modules early, including `vllm._custom_ops` and `vllm.compilation.passes.fusion.act_quant_fusion`. On the current MetaX runtime those imports can reference `_C::scaled_fp4_quant.out`, `_C::silu_and_mul_per_block_quant`, and newer `torch.accelerator` helpers before the MetaX plugin has registered compatible shims. In spawned EngineCore workers this prevents Qwen3.5 MTP from reaching generation.

## Changes

- Add `vllm_metax.compat` and import it at package import time.
- Register fragment schemas for the missing import-time `_C` custom ops.
- Backfill missing `torch.accelerator` helpers from `torch.cuda` when that module exists.
- Keep the legacy `triton_support` import path loading the same compatibility hooks.
- Add focused regression tests covering `act_quant_fusion` import and import safety when `torch.cuda` is absent.

## Before this fix

On the same MetaX validation environment, MTP could fail before generation:

- `079_qwen35_9b_mtp261_smoke.txt`: `RuntimeError: operator _C::scaled_fp4_quant.out does not exist`
- `084_qwen35_9b_mtp261_mtp_only_after_schema_fix.txt`: `AttributeError: module 'torch.accelerator' has no attribute 'empty_cache'`
- `088_qwen35_27b_w8a8_mtp261_mtp_only_9b_tokenizer.txt`: `RuntimeError: operator _C::scaled_fp4_quant.out does not exist`

## Validation

Remote MetaX C500 environment:

- Driver: 3.8.30
- MACA SDK: 3.5.3.20
- Python: 3.10.10
- vLLM: 0.23.0
- torch: 2.8.0+metax3.5.3.9

Checks:

- `python -m pytest tests/patch/test_triton_custom_op_schemas.py -q --confcutdir=tests/patch` -> 2 passed
- `import vllm_metax.quant_config; import vllm.compilation.passes.fusion.act_quant_fusion` -> ok
- `python -m py_compile ...` -> ok
- `git diff --check` -> ok

Validation matrix using the same prompt and `max_tokens=96`:

| Case | MTP | Load s | Generate s | Output tok/s | Repeated bigram ratio | Spec decode |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| Qwen3.5-9B | no | 90.289 | 3.995 | 24.0311 | 0.0125 | n/a |
| Qwen3.5-9B | yes | 93.406 | 3.352 | 28.6370 | 0.0125 | drafts=45, draft_tokens=90, accepted=50, per_pos=[30, 20] |
| Qwen3.5-27B-W8A8 | no | 99.703 | 9.338 | 10.2801 | 0.0444 | n/a |
| Qwen3.5-27B-W8A8 | yes | 102.532 | 4.434 | 21.6529 | 0.0000 | drafts=35, draft_tokens=70, accepted=60, per_pos=[31, 29] |

Both no-MTP and MTP paths generated normal output. The MTP cases also reported active spec-decode metrics, confirming the `qwen3_next_mtp`/`mtp` path was exercised rather than falling back to regular decoding.

Logs are archived on the validation machine under `/data/vllm-metax-contribution/ops/logs/079_*`, `084_*`, `088_*`, `092_*`, and `093_*`.

Notes:

- The available 30B-A3B model configs on the validation machine do not contain MTP metadata, so they were not used as Qwen3.5 MTP substitutes.
- Qwen3.5-27B-W8A8 has a `TokenizersBackend` tokenizer config that this Transformers environment cannot instantiate directly; the 27B smoke/validation runs use the local Qwen3.5-9B tokenizer workaround.

### Additional 35BA3B GPTQ validation

After the original import compatibility fix, I also downloaded and tested a ModelScope 35BA3B GPTQ checkpoint because the validation machine did not initially have a runnable 35BA3B MTP model:

- Downloaded: `potter001/gptq-Qwen3.6-35B-A3B-4bit-group` to `/data/vllm-metax-contribution/models/gptq-Qwen3.6-35B-A3B-4bit-group`
- Model metadata: `qwen3_5_moe`, `mtp_num_hidden_layers=1`, `quant_method=gptq`, 7 safetensors shards, 19.27 GiB after removing Git LFS cache
- Also checked but did not use for final validation:
  - official FP8: MetaX rejects `fp8 quantization is currently not supported in maca`
  - Eco-Tech W8A8: Ascend/msmodelslim format lacks vLLM quantization config and OOMs as unquantized MoE
  - FlagRelease Metax BF16: ~71.9 GiB and documented for TP=2, not usable on the single C500 validation setup

The GPTQ 35BA3B path exposed one additional vLLM 0.23 compatibility issue: `MoeWNA16Method.apply()` read `self.moe.disable_inplace`, but the current `FusedMoEConfig` does not always define that field. This PR now falls back to `False` when the field is absent and adds a focused regression test.

35BA3B GPTQ + MTP validation after that fix:

- `python -m pytest -q --confcutdir=tests/patch tests/patch/test_triton_custom_op_schemas.py tests/patch/test_moe_wna16_compat.py`: 3 passed
- Smoke log: `/data/vllm-metax-contribution/ops/logs/103_qwen36_35ba3b_gptq_mtp_after_moe_wna16_fix.txt`
  - loaded target + MTP drafter, `LOAD_S 130.03`
  - generated 32 tokens, `drafts=31`, `draft_tokens=62`, `accepted=0`
- Issue-like long check: `/data/vllm-metax-contribution/ops/logs/104_qwen36_35ba3b_gptq_mtp_issue_like_check.txt`
  - generated 128 tokens, `OUTPUT_TOKENS_PER_S 9.2379`
  - repetition ratios: bigram `0.0806`, trigram `0.0492`, 4-gram `0.0167`
  - spec-decode metrics: `drafts=127`, `draft_tokens=254`, `accepted=0`, `accepted_tokens_per_pos=[0, 0]`

The 35BA3B GPTQ output did not show the repeated corrupted loop reported in #261. The zero accepted-token count is called out explicitly because this GPTQ checkpoint plus tokenizer workaround exercises the MTP drafter path but does not demonstrate speedup.

Related to #261. This PR fixes MTP compatibility blockers found while reproducing #261. It does not claim to close the original repeated-output corruption without the exact original reproduction prompt and sampling parameters.

## 2026-07-02 dual-C500 FlagRelease 35BA3B validation

Validation environment:

- 2 x MetaX C500 64GB
- MACA 3.5.3.20, driver 3.8.30
- torch 2.8.0+metax3.5.3.9
- vLLM 0.23.0
- model: `FlagRelease/Qwen3.6-35B-A3B-nomtp-metax-FlagOS`
- model weights: 21 safetensors, 71,903,776,768 bytes
- tensor_parallel_size=2, max_model_len=2048, temperature=0.0, max_tokens=128

Before/after compatibility check:

- Before this patch, the base `ce08bf57` worktree fails while importing the MTP/triton-support path with `RuntimeError: operator _C::scaled_fp4_quant.out does not exist`.
- After this patch, `vllm_metax.patch.bugfix.triton_support.custom_op_schemas` and `vllm.compilation.passes.fusion.act_quant_fusion` import successfully; `_C::scaled_fp4_quant.out` and `_C::silu_and_mul_per_block_quant` schemas are present.
- Focused tests: `python -m pytest -q --confcutdir=tests/patch tests/patch/test_triton_custom_op_schemas.py tests/patch/test_moe_wna16_compat.py` -> 3 passed.

35BA3B MTP/no-MTP comparison on the same prompt:

| Case | MTP | num_speculative_tokens | output tok/s | repeat 2g | repeat 3g | repeat 4g | accepted |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| no-MTP | no | n/a | 7.3670 | 0.0267 | 0.0 | 0.0 | n/a |
| MTP | yes | 2 | 12.8181 | 0.0267 | 0.0 | 0.0 | 79/98, per pos `[46, 33]` |
| MTP | yes | 1 | 14.1913 | 0.0267 | 0.0 | 0.0 | 63/65, per pos `[63]` |

The MTP runs initialized as `SpeculativeConfig(method='mtp', num_spec_tokens=...)`, loaded the MTP drafter, emitted `vllm:spec_decode_*` metrics, and did not show the repeated corrupted-output loop in this validation prompt.