### PR TITLE
[Perf] Optimize sampling performance

### DIFF
--- a/vllm_metax/envs.py
+++ b/vllm_metax/envs.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     VLLM_FUSED_MOE_CHUNK_SIZE: int = 16 * 1024
     VLLM_METAX_USE_FP8_SPARSE_ATTN_INDEXER: bool = False
     VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK: bool = False
+    VLLM_METAX_USE_FLASHINFER_SAMPLER: bool = False
 
 environment_variables: dict[str, Callable[[], Any]] = {
     # ================== Installation Time Env Vars ==================
@@ -84,6 +85,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # if set, enable sglang fused grouped topk ops on deepseek and kimi model
     "VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK": lambda: bool(
         int(os.getenv("VLLM_METAX_USE_SGL_FUSED_MOE_GROUPED_TOPK", "0"))
+    ),
+    # if set, enable upstream FlashInfer top-k/top-p sampler on Maca.
+    # Defaults to the upstream env only when explicitly set; otherwise disabled.
+    "VLLM_METAX_USE_FLASHINFER_SAMPLER": lambda: bool(
+        int(
+            os.getenv(
+                "VLLM_METAX_USE_FLASHINFER_SAMPLER",
+                os.getenv("VLLM_USE_FLASHINFER_SAMPLER", "0"),
+            )
+        )
     ),
     # =================== Debug Env Vars ==================
     # if set, use vllm's fused_moe implementation instead of maca's one for debugging and comparison

--- a/vllm_metax/patch/bugfix/triton_support/topk_topp_sampler.py
+++ b/vllm_metax/patch/bugfix/triton_support/topk_topp_sampler.py
@@ -9,7 +9,19 @@
 # -----------------------------------------------
 
 import torch
-from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p_pytorch
+import torch.nn as nn
+from vllm import envs
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.platforms import CpuArchEnum, current_platform
+from vllm.v1.sample.ops.topk_topp_sampler import (
+    apply_top_k_top_p_pytorch,
+    random_sample,
+)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_FLASHINFER_MAX_SAMPLING_ROUNDS = 32
 
 
 def apply_top_k_top_p(
@@ -22,9 +34,165 @@ def apply_top_k_top_p(
     return apply_top_k_top_p_pytorch(logits, k, p)
 
 
+def _make_uniform_samples(logits: torch.Tensor) -> torch.Tensor:
+    return torch.rand(
+        (_FLASHINFER_MAX_SAMPLING_ROUNDS, logits.shape[0]),
+        device=logits.device,
+        dtype=torch.float32,
+    )
+
+
+def _select_failed_values(
+    value: torch.Tensor | int | float | None, failed: torch.Tensor
+) -> torch.Tensor | int | float | None:
+    if isinstance(value, torch.Tensor):
+        return value[failed]
+    return value
+
+
+def _replace_failed_samples(
+    logits: torch.Tensor,
+    k: torch.Tensor | None,
+    p: torch.Tensor | None,
+    samples: torch.Tensor,
+    success: torch.Tensor,
+) -> torch.Tensor:
+    if bool(success.all().item()):
+        return samples
+
+    failed = ~success
+    fallback_logits = apply_top_k_top_p(
+        logits[failed].clone(),
+        _select_failed_values(k, failed),
+        _select_failed_values(p, failed),
+    )
+    fallback_probs = fallback_logits.softmax(dim=-1, dtype=torch.float32)
+    fallback_samples = random_sample(fallback_probs, {})
+
+    samples = samples.clone()
+    samples[failed] = fallback_samples.to(samples.dtype)
+    return samples
+
+
+def flashinfer_sample(
+    logits: torch.Tensor,
+    k: torch.Tensor | None,
+    p: torch.Tensor | None,
+    generators: dict[int, torch.Generator],
+) -> torch.Tensor:
+    import flashinfer
+
+    assert not generators
+    assert not (k is None and p is None)
+
+    uniform_samples = _make_uniform_samples(logits)
+    if k is None:
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        samples, success = flashinfer.sampling.top_p_sampling_from_probs(
+            probs, uniform_samples, p, deterministic=True
+        )
+    elif p is None:
+        probs = logits.softmax(dim=-1, dtype=torch.float32)
+        samples, success = flashinfer.sampling.top_k_sampling_from_probs(
+            probs, uniform_samples, k, deterministic=True
+        )
+    else:
+        samples, success = flashinfer.sampling.top_k_top_p_sampling_from_logits(
+            logits, uniform_samples, k, p, deterministic=True
+        )
+
+    samples = _replace_failed_samples(logits, k, p, samples, success)
+    return samples.view(-1)
+
+
 import vllm.v1.sample.ops.topk_topp_sampler
 
 vllm.v1.sample.ops.topk_topp_sampler.apply_top_k_top_p = apply_top_k_top_p
+vllm.v1.sample.ops.topk_topp_sampler.flashinfer_sample = flashinfer_sample
+
+
+def _get_flashinfer_backend_cls():
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+    from vllm_metax.platform import register_attention_backends
+
+    register_attention_backends()
+    return AttentionBackendEnum.FLASHINFER.get_class()
+
+
+def _supports_flashinfer_sampler_platform() -> bool:
+    return current_platform.is_cuda() or (
+        current_platform.is_out_of_tree() and current_platform.is_cuda_alike()
+    )
+
+
+def _topk_topp_sampler_init(self, logprobs_mode="raw_logprobs") -> None:
+    nn.Module.__init__(self)
+    self.logprobs_mode = logprobs_mode
+
+    if (
+        logprobs_mode not in ("processed_logits", "processed_logprobs")
+        and _supports_flashinfer_sampler_platform()
+    ):
+        if envs.VLLM_USE_FLASHINFER_SAMPLER:
+            flashinfer_backend = _get_flashinfer_backend_cls()
+            capability = current_platform.get_device_capability()
+            assert capability is not None
+            if flashinfer_backend.supports_compute_capability(capability):
+                logger.warning_once(
+                    "Using FlashInfer for top-p & top-k sampling.",
+                    scope="global",
+                )
+                self.forward = self.forward_cuda
+            elif envs.is_set("VLLM_USE_FLASHINFER_SAMPLER"):
+                capability_str = capability.as_version_str()
+                raise RuntimeError(
+                    "FlashInfer does not support compute capability "
+                    f"{capability_str}, unset VLLM_USE_FLASHINFER_SAMPLER=1."
+                )
+            else:
+                logger.warning_once(
+                    "FlashInfer top-p/top-k sampling not supported on "
+                    "compute capability %s; falling back to PyTorch-native "
+                    "sampler. Set VLLM_USE_FLASHINFER_SAMPLER=0 to silence.",
+                    capability.as_version_str(),
+                )
+                self.forward = self.forward_native
+        else:
+            self.forward = self.forward_native
+    elif current_platform.is_cpu():
+        arch = current_platform.get_cpu_architecture()
+        if arch in (CpuArchEnum.RISCV, CpuArchEnum.POWERPC):
+            self.forward = self.forward_native
+        else:
+            self.forward = self.forward_cpu
+    elif current_platform.is_xpu():
+        if envs.VLLM_XPU_USE_SAMPLER_KERNEL:
+            self.forward = self.forward_xpu
+        else:
+            self.forward = self.forward_native
+    elif (
+        logprobs_mode not in ("processed_logits", "processed_logprobs")
+        and rocm_aiter_ops.is_enabled()
+    ):
+        try:
+            import aiter.ops.sampling  # noqa: F401
+
+            self.aiter_ops = torch.ops.aiter
+            logger.info_once(
+                "Using aiter sampler on ROCm (lazy import, sampling-only)."
+            )
+            self.forward = self.forward_hip
+        except ImportError:
+            logger.warning_once(
+                "aiter.ops.sampling is not available on ROCm. "
+                "Falling back to forward_native implementation."
+            )
+            self.forward = self.forward_native
+    else:
+        self.forward = self.forward_native
+
+
+vllm.v1.sample.ops.topk_topp_sampler.TopKTopPSampler.__init__ = _topk_topp_sampler_init
 
 import vllm.v1.sample.rejection_sampler
 

--- a/vllm_metax/platform.py
+++ b/vllm_metax/platform.py
@@ -788,9 +788,10 @@ MacaPlatform.log_warnings()
 # --------------------------------------------------
 # Note: Put all env Override here for Maca platform
 mx_envs.override_vllm_env(
-    "VLLM_USE_FLASHINFER_SAMPLER", False, "flashinfer sampler are not supported on maca"
+    "VLLM_USE_FLASHINFER_SAMPLER",
+    mx_envs.VLLM_METAX_USE_FLASHINFER_SAMPLER,
+    "controlled by VLLM_METAX_USE_FLASHINFER_SAMPLER; disabled by default",
 )
-
 mx_envs.override_vllm_env(
     "VLLM_ENGINE_READY_TIMEOUT_S", 7200, "set timeout to 7200s for model loading"
 )


### PR DESCRIPTION
## Purpose

Enable FlashInfer top-k/top-p sampler on MetaX-MACA for the ModelRunner V1 sampling path by:

- keeping `VLLM_USE_FLASHINFER_SAMPLER` under upstream control instead of forcing it off on MetaX
- allowing MetaX OOT `cuda_alike` platform to enter the upstream FlashInfer sampler path
- adapting vLLM's FlashInfer sampler wrapper to MetaX FlashInfer's legacy `uniform_samples` API
- preserving fallback to native sampling when FlashInfer rejection sampling fails

## Performance

main

    ============ Serving Benchmark Result ============
    Successful requests:                     500
    Failed requests:                         0
    Request rate configured (RPS):           1.27
    Benchmark duration (s):                  411.75
    Total input tokens:                      512000
    Total generated tokens:                  512000
    Request throughput (req/s):              1.21
    Output token throughput (tok/s):         1243.46
    Peak output token throughput (tok/s):    1877.00
    Peak concurrent requests:                51.00
    Total token throughput (tok/s):          2486.93
    ---------------Time to First Token----------------
    Mean TTFT (ms):                          164.43
    Median TTFT (ms):                        154.30
    P99 TTFT (ms):                           286.41
    -----Time per Output Token (excl. 1st token)------
    Mean TPOT (ms):                          24.73
    Median TPOT (ms):                        24.57
    P99 TPOT (ms):                           28.91
    ---------------Inter-token Latency----------------
    Mean ITL (ms):                           24.71
    Median ITL (ms):                         22.43
    P99 ITL (ms):                            100.77
    ----------------End-to-end Latency----------------
    Mean E2EL (ms):                          25465.82
    Median E2EL (ms):                        25301.04
    P99 E2EL (ms):                           29755.19
    ==================================================

PR

    ============ Serving Benchmark Result ============
    Successful requests:                     500
    Failed requests:                         0
    Request rate configured (RPS):           1.60
    Benchmark duration (s):                  332.15
    Total input tokens:                      512000
    Total generated tokens:                  512000
    Request throughput (req/s):              1.51
    Output token throughput (tok/s):         1541.49
    Peak output token throughput (tok/s):    2396.00
    Peak concurrent requests:                59.00
    Total token throughput (tok/s):          3082.99
    ---------------Time to First Token----------------
    Mean TTFT (ms):                          171.55
    Median TTFT (ms):                        161.19
    P99 TTFT (ms):                           278.82
    -----Time per Output Token (excl. 1st token)------
    Mean TPOT (ms):                          24.95
    Median TPOT (ms):                        25.28
    P99 TPOT (ms):                           27.76
    ---------------Inter-token Latency----------------
    Mean ITL (ms):                           24.93
    Median ITL (ms):                         21.88
    P99 ITL (ms):                            107.82
    ----------------End-to-end Latency----------------
    Mean E2EL (ms):                          25699.71
    Median E2EL (ms):                        26033.47
    P99 E2EL (ms):                           28550.91
    ==================================================

## Correctness

### CEval

main

    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | high_school_politics                     |    19 |  0.9474 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | high_school_geography                    |    19 |  0.8421 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | middle_school_politics                   |    21 |  1      | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | middle_school_geography                  |    12 |  0.9167 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | OVERALL                                  |  1346 |  0.8655 | -              |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+

PR

    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | high_school_politics                     |    19 |  0.9474 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | high_school_geography                    |    19 |  0.9474 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | middle_school_politics                   |    21 |  0.9524 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | middle_school_geography                  |    12 |  0.9167 | Social Science |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+
    | untitled | ceval     | mean_acc | OVERALL                                  |  1346 |  0.8692 | -              |
    +----------+-----------+----------+------------------------------------------+-------+---------+----------------+

### GSM8K

main

    dataset    version    metric    mode      vllm-api-general-chat
    ---------  ---------  --------  ------  -----------------------
    gsm8k      271d0b     accuracy  gen                       86.96

PR

    dataset    version    metric    mode      vllm-api-general-chat
    ---------  ---------  --------  ------  -----------------------
    gsm8k      271d0b     accuracy  gen                       88.25
