### PR TITLE
docs: add Qwen/Qwen2.5-1.5B-Instruct to supported models

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -40,7 +40,7 @@ Here the plugin would list all the **tested** model on Maca.
 | `MixtralForCausalLM` | Mixtral-8x7B, Mixtral-8x7B-Instruct | `mistralai/Mixtral-8x7B-v0.1`, `mistralai/Mixtral-8x7B-Instruct-v0.1`, `mistral-community/Mixtral-8x22B-v0.1`, etc. | ✅︎ | ✅︎ |
 | `MPTForCausalLM` | MPT, MPT-Instruct, MPT-Chat, MPT-StoryWriter | `mosaicml/mpt-7b`, `mosaicml/mpt-7b-storywriter`, `mosaicml/mpt-30b`, etc. | | ✅︎ |
 | `QWenLMHeadModel` | Qwen | `Qwen/Qwen-7B`, `Qwen/Qwen-7B-Chat`, etc. | ✅︎ | ✅︎ |
-| `Qwen2ForCausalLM` | QwQ, Qwen2 | `Qwen/QwQ-32B-Preview`, `Qwen/Qwen2-7B-Instruct`, `Qwen/Qwen2-7B`, etc. | ✅︎ | ✅︎ |
+| `Qwen2ForCausalLM` | QwQ, Qwen2, Qwen2.5 | `Qwen/QwQ-32B-Preview`, `Qwen/Qwen2-7B-Instruct`, `Qwen/Qwen2-7B`, `Qwen/Qwen2.5-1.5B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `Qwen2MoeForCausalLM` | Qwen2MoE | `Qwen/Qwen1.5-MoE-A2.7B`, `Qwen/Qwen1.5-MoE-A2.7B-Chat`, etc. | ✅︎ | ✅︎ |
 | `Qwen3ForCausalLM` | Qwen3 | `Qwen/Qwen3-8B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3MoeForCausalLM` | Qwen3MoE | `Qwen/Qwen3-30B-A3B`, etc. | ✅︎ | ✅︎ |


### PR DESCRIPTION
## Summary

Add `Qwen/Qwen2.5-1.5B-Instruct` to the list of tested models for the MetaX (MACA) backend in `docs/models/supported_models.md`.

Qwen2.5 uses the `Qwen2ForCausalLM` architecture, which is already supported on MetaX. This PR records a concrete, end-to-end validated model ID under that row (the `Example HF Models` column previously listed only Qwen2 / QwQ IDs).

## Changes

- `docs/models/supported_models.md`: add `Qwen/Qwen2.5-1.5B-Instruct` to the `Qwen2ForCausalLM` example list, and note the `Qwen2.5` family in the models column.

## Validation

Offline generation was run on a single MetaX C500 and produced correct, coherent output.

### Environment

| Component | Version |
|-----------|---------|
| GPU | MetaX C500 64GB |
| MACA | 3.3.0.15 (KMD 3.8.30) |
| torch | 2.8.0+metax3.3.0.2 |
| vLLM (upstream, `releases/v0.13.0`, empty device) | 0.13.1.dev0 |
| vllm-metax plugin | 0.13.0 |
| mcoplib | 0.3.1+maca3.3.0.15.torch2.8 |

### Result

Engine initialized on the MACA `FLASH_ATTN` backend and produced 3/3 completions:

```
Prompt: 'The capital of France is'
Output: ' Paris. The capital of France is also the capital of which country? ...'

Prompt: 'Explain quantum computing in one sentence.'
Output: ' Quantum computing is a type of computing that uses quantum-mechanical phenomena, such as superposition and entanglement, to perform operations on data.'

Prompt: 'Write a short Python function that reverses a string.'
Output: ' ... def reverse_string(s: str) -> str: ...'
```

## Test Plan

```bash
# MACA env + precompiled mcoplib kernels + HF mirror
export USE_PRECOMPILED_KERNEL=1
python validate_qwen2_5_1_5b.py
```

Expected: engine initializes with the metax platform activated and prints three coherent completions ending in `VALIDATION OK`.
