### PR TITLE
Add tuned MoE Triton configs for MetaX C500 (MXC500)

### DIFF
--- a/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=128,N=768,device_name=MXC500.json
+++ b/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=128,N=768,device_name=MXC500.json
@@ -1,0 +1,262 @@
+{
+  "1": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 32,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 32,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "8": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "16": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "32": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "64": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "128": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "256": {
+    "stage1": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "512": {
+    "stage1": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "1024": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "2048": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  }
+}

--- a/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=60,N=1408,device_name=MXC500.json
+++ b/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=60,N=1408,device_name=MXC500.json
@@ -1,0 +1,262 @@
+{
+  "1": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "8": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "16": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "32": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 32,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "64": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "128": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "256": {
+    "stage1": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "512": {
+    "stage1": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "1024": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "2048": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 2,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  }
+}

--- a/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
+++ b/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
@@ -1,0 +1,262 @@
+{
+  "1": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 16,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 16,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "8": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "16": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "32": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 4,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "64": {
+    "stage1": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 16,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "128": {
+    "stage1": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "256": {
+    "stage1": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 32,
+      "BLOCK_SIZE_N": 64,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "512": {
+    "stage1": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 64,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "1024": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  },
+  "2048": {
+    "stage1": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    },
+    "stage2": {
+      "BLOCK_SIZE_M": 128,
+      "BLOCK_SIZE_N": 128,
+      "BLOCK_SIZE_K": 64,
+      "GROUP_SIZE_M": 1,
+      "num_warps": 8,
+      "num_stages": 3,
+      "pipeline": "basic",
+      "scenario": "",
+      "ACCF32": false,
+      "SPLIT_K": 1
+    }
+  }
+}

--- a/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
+++ b/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
@@ -5,7 +5,7 @@
       "BLOCK_SIZE_N": 64,
       "BLOCK_SIZE_K": 64,
       "GROUP_SIZE_M": 1,
-      "num_warps": 8,
+      "num_warps": 4,
       "num_stages": 3,
       "pipeline": "basic",
       "scenario": "",

--- a/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
+++ b/vllm_metax/model_executor/layers/fused_moe/configs/H=2048,E=64,N=1408,device_name=MXC500.json
@@ -4,7 +4,7 @@
       "BLOCK_SIZE_M": 16,
       "BLOCK_SIZE_N": 64,
       "BLOCK_SIZE_K": 64,
-      "GROUP_SIZE_M": 16,
+      "GROUP_SIZE_M": 1,
       "num_warps": 8,
       "num_stages": 3,
       "pipeline": "basic",


### PR DESCRIPTION
## Summary

Add tuned two-stage Triton MoE configs for MetaX C500 (`device_name=MXC500`) covering three popular MoE shapes that currently fall back to the generic default config and emit the `Using default MoE config. Performance might be sub-optimal!` warning.

| Shape (H,E,N) | Top-K | Representative model | Architecture |
|---|---|---|---|
| 2048, 60, 1408 | 4 | `Qwen/Qwen1.5-MoE-A2.7B` | `Qwen2MoeForCausalLM` |
| 2048, 64, 1408 | 6 | `deepseek-ai/DeepSeek-V2-Lite` | `DeepseekV2ForCausalLM` |
| 2048, 128, 768 | 8 | `Qwen/Qwen3-30B-A3B` | `Qwen3MoeForCausalLM` |

## Problem

`vllm_metax` selects the fused-MoE Triton tile from JSON configs keyed by `(H, E, N, device_name[, dtype])`. When no matching tuned config exists, it falls back to `get_default_config`, which is noticeably slower for prefill / large-batch shapes.

## Method

The upstream `benchmarks/kernels/benchmark_moe.py` tunes the upstream `fused_experts`, but on MACA the runtime path goes through the OOT `vllm_metax.model_executor.layers.fused_moe.fused_moe.fused_experts` (verified to be a different object). Therefore I wrote a small micro-benchmark (`moe_tune.py`) that:

- Forces a candidate tile via `vllm.model_executor.layers.fused_moe.override_config`.
- Times a single `vllm_metax` `fused_experts()` call with random weights (no model download needed).
- Uses CUDA events + `torch.cuda.synchronize()`, warmup + median over repeated iters.
- Wraps the winning flat tile into the MetaX two-stage schema (`stage1`/`stage2` + `ACCF32`/`SPLIT_K`/`pipeline`/`scenario`).

Correctness was verified with `torch.allclose(rtol=2e-2, atol=2e-2)` between default-tile and tuned-tile outputs, and config pickup was confirmed with `get_moe_configs()`.

## Results (kernel-level, MetaX C500)

| Model shape | M | Default (ms) | Tuned (ms) | Speedup |
|---|---:|---:|---:|:--:|
| Qwen1.5-MoE E=60,N=1408 | 64 | 1.154 | 0.915 | **1.26x** |
| | 256 | 1.291 | 1.025 | **1.26x** |
| | 1024 | 2.340 | 1.567 | **1.49x** |
| | 2048 | 4.559 | 2.589 | **1.76x** |
| DeepSeek-V2-Lite E=64,N=1408 | 128 | 1.260 | 1.046 | **1.21x** |
| | 512 | 1.642 | 1.311 | **1.25x** |
| | 1024 | 3.163 | 1.720 | **1.84x** |
| | 2048 | 6.793 | 3.081 | **2.20x** |
| Qwen3-30B-A3B E=128,N=768 | 256 | 1.505 | 1.189 | **1.27x** |
| | 1024 | 2.650 | 1.850 | **1.43x** |
| | 2048 | 4.424 | 2.755 | **1.61x** |

Small-M shapes are kept at or near the default tile to avoid decode-latency regressions.

## Testing environment

- MetaX C500 (currently visible as an **sGPU slice: 16 GB VRAM / 25 % compute** due to the test container configuration)
- MACA 3.3.0.15
- vllm `0.13.1.dev0` / vllm_metax `0.13.0` / mcoplib `0.3.1`
- torch `2.8.0+metax3.3.0.2`

The tile shapes (BLOCK_SIZE / warps / stages) are per-SM properties and should transfer to a full C500; the grid-level parameters (GROUP_SIZE_M=1, SPLIT_K=1) are conservative. I would welcome a maintainer running the same `moe_tune.py` on a full C500 to cross-check, but the current data already shows clear, reproducible wins on real MACA hardware.

## Notes

- No code changes; this PR only adds three JSON config files.
- All configs use `ACCF32: false` and `SPLIT_K: 1` for low-risk deployment.
- The helper scripts and raw tuning data are archived at https://www.gitlink.org.cn/LindseyMei/vllm_metax/tree/master/moe_tuning for reference.

Signed-off-by: LindseyMei <648816901@qq.com>
