### PR TITLE
[CI] run pre-commit on the default branch

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Purpose

`.github/workflows/pre-commit.yml` triggers on `push: branches: [main]`, but this fork has no `main` branch:

```
$ git ls-remote --heads https://github.com/MetaX-MACA/vLLM-metax | grep -c 'refs/heads/main$'
0

$ git ls-remote --heads https://github.com/MetaX-MACA/vLLM-metax | head -8
0cc712a3678d6c569557f8a7b1bc84e18960690f	refs/heads/ai2-dev
9902b34ed881d439fc9ba122fbde4e3dece708d4	refs/heads/fix-int8-w8a8-mla
e25dc89e271b070e2933b591b58e3d0afc89c041	refs/heads/master
97da48a64def90e7ecfc71df66c52fe87da97351	refs/heads/releases/v0.10.2
7eeeb9e523467e1c1484b2e8304c2b401e4f46a8	refs/heads/releases/v0.11.2
b12e350951d57bd20e3da50260387ba534f8ef1e	refs/heads/releases/v0.12.0
cd578d635b400ad43a6ae2f74a0731bd5859d207	refs/heads/releases/v0.13.0
3fac66a4b39a37d853ee9ddaf1753c9fe19b2288	refs/heads/releases/v0.14.0
```

The default branch is `master`, and the sibling workflow in the same directory already says so (`.github/workflows/vllm_metax_tests.yaml`: `push: branches: - "master"`). `pre-commit.yml` came from vllm-project/vllm, whose default branch *is* `main`, and the name was never adapted. So the `push` trigger has matched nothing since the workflow landed, and the lint gate has never run on the default branch. The `pull_request` trigger still fires, so this is the second safety net rather than the only one, but the net is dead.

## Changes

One line:

```diff
   push:
-    branches: [main]
+    branches: [master]
```

## Test Plan

The gate this re-arms is `pre-commit run --all-files --hook-stage manual` (`.github/workflows/pre-commit.yml:30`, via `pre-commit/action@v3.0.1` with `extra_args: --all-files --hook-stage manual`). `.pre-commit-config.yaml` defines 17 hooks for that stage.

## Test Result

The change is confined to a workflow trigger, so it cannot alter any hook's outcome — what it alters is whether the job runs at all on `master`. What it does change is verifiable directly:

```
$ grep -A2 '^  push:' .github/workflows/pre-commit.yml
  push:
    branches: [master]
```

and `master` is now a branch that exists, so `on: push` will match it.
