### PR TITLE
Use max_seq_len instead of prefill_seq_lens.max().item() to reduce CPU-side overhead

### DIFF
--- a/vllm_metax/v1/attention/backends/flash_attn.py
+++ b/vllm_metax/v1/attention/backends/flash_attn.py
@@ -656,7 +656,7 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             prefill_seq_lens_cpu = common_attn_metadata.seq_lens_cpu[
                 num_decodes:num_reqs
             ]
-            prefill_max_seq_len = int(prefill_seq_lens_cpu.max().item())
+            prefill_max_seq_len = max_seq_len
             prefill_block_table_tensor = common_attn_metadata.block_table_tensor[
                 num_decodes:num_reqs
             ]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
In vllm-metax/v1/attention/backends/flash_attn.py, when building attn_metadata, prefill_seq_lens.max().item() is used to obtain the sequence length of requests. The .item() operation triggers mcStreamSynchronize, which is a stream synchronization primitive that forces the CPU to wait for all enqueued GPU work to complete, causing excessive CPU-side latency. Replacing prefill_seq_lens.max().item() with max_seq_len eliminates this synchronization point. Although this introduces a small amount of extra GPU memory usage, it significantly reduces CPU-side overhead and improves end-to-end performance.

<img width="1196" height="594" alt="image" src="https://github.com/user-attachments/assets/b26ea086-d996-4988-be3e-3e162f5d2f31" />


## Test Plan
This optimization result can be confirmed by inspecting the timeline after the optimization.

## Test Result
<img width="1912" height="914" alt="img_v3_0213q_cdbbc854-8a8b-4055-a9ca-5f118fae883g" src="https://github.com/user-attachments/assets/33da3155-3f3f-4617-b564-864e24558d41" />
